### PR TITLE
fix(nfse): adiciona CodigoCnae no provider de Campinas (erro L999)

### DIFF
--- a/erp/scripts/test-nfse-campinas.ts
+++ b/erp/scripts/test-nfse-campinas.ts
@@ -41,10 +41,12 @@ async function main() {
   const provider = new CampinasNfseProvider(
     certBuffer,
     certSenha,
-    inscricao,
-    itemListaServico,
-    undefined,
-    cnae
+    {
+      inscricaoMunicipal: inscricao,
+      itemListaServico,
+      codigoCnae: cnae,
+      simplesNacional: process.env.SIMPLES_NACIONAL !== "false",
+    }
   );
 
   console.log("📡  Enviando NFS-e de teste (R$ 1,00)...");

--- a/erp/src/lib/nfse/campinas.provider.ts
+++ b/erp/src/lib/nfse/campinas.provider.ts
@@ -15,6 +15,31 @@ const WSDL_PROD =
 // Código IBGE de Campinas-SP
 const CODIGO_MUNICIPIO_CAMPINAS = 3509502;
 
+// ---------------------------------------------------------------------------
+// Config object — evita constructor com 7+ parâmetros posicionais
+// ---------------------------------------------------------------------------
+
+export interface CampinasNfseConfig {
+  /** Inscrição Municipal do prestador */
+  inscricaoMunicipal: string;
+  /** Código de serviço LC116 (ex: "01.06") */
+  itemListaServico: string;
+  /** Código de tributação municipal (opcional) */
+  codigoTributacao?: string;
+  /**
+   * CNAE do prestador — Campinas exige 9 dígitos na tag <CodigoCnae>.
+   * Pode ser passado com ou sem formatação (ex: "6204-0/00-01" ou "620400001").
+   * O constructor normaliza automaticamente removendo caracteres não numéricos.
+   */
+  codigoCnae?: string;
+  /**
+   * Optante pelo Simples Nacional.
+   * Aplica-se ao schema ABRASF (Campinas).
+   * São Paulo (TributacaoRPS) e Taboão (CONAM) não têm campo equivalente.
+   */
+  simplesNacional?: boolean;
+}
+
 export class CampinasNfseProvider implements NfseProvider {
   private campinas: NfseCampinas;
   private inscricaoMunicipal: string;
@@ -26,23 +51,18 @@ export class CampinasNfseProvider implements NfseProvider {
   constructor(
     certBuffer: Buffer,
     certPassword: string,
-    inscricaoMunicipal: string,
-    itemListaServico: string,
-    codigoTributacao?: string,
-    codigoCnae?: string,
-    simplesNacional = false
+    config: CampinasNfseConfig
   ) {
     const wsdl =
       process.env.NFSE_ENV === "production" ? WSDL_PROD : WSDL_HOMOLOG;
     this.campinas = new NfseCampinas(wsdl, certBuffer, certPassword);
-    this.inscricaoMunicipal = inscricaoMunicipal;
-    this.itemListaServico = itemListaServico;
-    this.codigoTributacao = codigoTributacao;
-    // Campinas exige CNAE com 9 dígitos (ex: "620400001").
-    // Normaliza aqui para garantir consistência independente de quem instanciar
-    // (ex: "6204-0/00-01" → "620400001", "6204000" → "6204000" mantido como está).
-    this.codigoCnae = codigoCnae?.replace(/\D/g, "") || undefined;
-    this.simplesNacional = simplesNacional;
+    this.inscricaoMunicipal = config.inscricaoMunicipal;
+    this.itemListaServico = config.itemListaServico;
+    this.codigoTributacao = config.codigoTributacao;
+    // Normaliza CNAE removendo caracteres não numéricos
+    // (ex: "6204-0/00-01" → "620400001"). Campinas exige 9 dígitos.
+    this.codigoCnae = config.codigoCnae?.replace(/\D/g, "") || undefined;
+    this.simplesNacional = config.simplesNacional ?? false;
   }
 
   async emitNFSe(input: EmitNfseInput): Promise<EmitNfseResult> {

--- a/erp/src/lib/nfse/factory.ts
+++ b/erp/src/lib/nfse/factory.ts
@@ -138,18 +138,18 @@ export async function getNfseProviderForCompany(
       // O constructor do CampinasNfseProvider já normaliza o CNAE internamente.
       // Passamos o valor bruto do banco; a normalização (remoção de não-dígitos) é feita lá.
       const cnaeNormalizado = config.cnae ?? undefined;
-      // OptanteSimplesNacional: aplica-se ao schema ABRASF (Campinas).
-      // São Paulo (Nota Paulistana v1) usa TributacaoRPS="T" sem este campo.
-      // Taboão da Serra (CONAM) usa cClassTrib/codNBS sem equivalente de Simples.
-      const isSimples = config.taxRegime === "SIMPLES_NACIONAL";
       const campinasProvider = new CampinasNfseProvider(
         certBuffer,
         certPassword,
-        inscricaoMunicipal,
-        itemListaServico,
-        config.codigoTributacaoMunicipio ?? undefined,
-        cnaeNormalizado,
-        isSimples
+        {
+          inscricaoMunicipal,
+          itemListaServico,
+          codigoTributacao: config.codigoTributacaoMunicipio ?? undefined,
+          codigoCnae: cnaeNormalizado,
+          // OptanteSimplesNacional: aplica-se ao schema ABRASF (Campinas).
+          // São Paulo (TributacaoRPS) e Taboão (CONAM) não têm campo equivalente.
+          simplesNacional: config.taxRegime === "SIMPLES_NACIONAL",
+        }
       );
       providerCache.set(companyId, { provider: campinasProvider, expiresAt: Date.now() + CACHE_TTL_MS });
       return campinasProvider;


### PR DESCRIPTION
## Problema
Ao emitir NFS-e via WebService ABRASF 2.03 em Campinas, o campo `<CodigoCnae>` não estava sendo enviado. O suporte da prefeitura confirmou que a CNAE deve ser informada nessa tag com **9 dígitos**.

**Erro:** `L999 - Configuração da atividade não encontrado`

## Solução
- `campinas.provider.ts`: novo parâmetro `codigoCnae` no construtor; envia `CodigoCnae` no bloco `Servico` quando informado
- `factory.ts`: lê campo `cnae` do `FiscalConfig` (já existente no schema), normaliza para 9 dígitos e repassa ao provider
- `test-nfse-campinas.ts`: aceita variável de ambiente `CNAE` para testes manuais

## Teste
```bash
CERT_PATH=cert.pfx \
CERT_SENHA=senha \
INSCRICAO_MUNICIPAL=00818959-5 \
CNPJ=47864248000164 \
ITEM_LISTA=01.06 \
CNAE=620400001 \
NFSE_ENV=homolog \
npx tsx scripts/test-nfse-campinas.ts
```

## Configuração
Certifique-se que o campo **CNAE** está preenchido nas Configurações → Fiscal da TrustCloud com o valor `620400001`.