### PR TITLE
feat(whatsapp-service): auto-reconecta sessões salvas no startup

### DIFF
--- a/whatsapp-service/src/index.ts
+++ b/whatsapp-service/src/index.ts
@@ -237,6 +237,36 @@ const server = app.listen(PORT, () => {
 });
 
 // ============================================
+// Auto-reconnect sessions saved in DB
+// ============================================
+
+(async () => {
+  try {
+    const rows = await prisma.$queryRaw<{ companyId: string }[]>`
+      SELECT DISTINCT "companyId" FROM "baileysAuthState"
+    `;
+    if (rows.length === 0) {
+      console.log("[Startup] No saved sessions found, skipping auto-reconnect");
+      return;
+    }
+    console.log(
+      `[Startup] Auto-reconnecting ${rows.length} company session(s)...`
+    );
+    for (const { companyId } of rows) {
+      console.log(`[Startup] Scheduling reconnect for company: ${companyId}`);
+      baileysProvider.initiateQrCode(companyId, true).catch((err) => {
+        console.error(`[Startup] Failed to reconnect ${companyId}:`, err);
+      });
+    }
+  } catch (err) {
+    console.error(
+      "[Startup] Error loading saved sessions for auto-reconnect:",
+      err
+    );
+  }
+})();
+
+// ============================================
 // Graceful Shutdown
 // ============================================
 


### PR DESCRIPTION
## Problema
Após um restart do serviço, todas as conexões WhatsApp eram perdidas e cada empresa precisava escanear o QR novamente manualmente.

## Solução
Ao subir o servidor, busca todos os `companyId` distintos salvos em `baileysAuthState` e chama `baileysProvider.initiateQrCode(companyId, true)` para cada um, restaurando as sessões automaticamente com as credenciais persistidas no banco.

## Arquivos alterados
- `whatsapp-service/src/index.ts` — bloco de auto-reconexão após `app.listen`