### PR TITLE
fix(whatsapp-service): falha no startup se API_KEY não configurada

### DIFF
--- a/whatsapp-service/src/index.ts
+++ b/whatsapp-service/src/index.ts
@@ -10,6 +10,33 @@ const PORT = parseInt(process.env.WHATSAPP_SERVICE_PORT || "3001", 10);
 const API_KEY = process.env.WHATSAPP_SERVICE_API_KEY || "";
 
 // ============================================
+// Startup config validation
+// ============================================
+
+if (!API_KEY) {
+  console.error(
+    "[FATAL] WHATSAPP_SERVICE_API_KEY não está definida. " +
+      "O serviço não pode subir sem uma chave de API. " +
+      "Defina a variável de ambiente e reinicie."
+  );
+  process.exit(1);
+}
+
+const WEBHOOK_URL_LOG = process.env.WHATSAPP_WEBHOOK_URL || "(não definida)";
+const SERVICE_BASE_URL_LOG =
+  process.env.WHATSAPP_SERVICE_BASE_URL || `http://localhost:${PORT}`;
+const maskedKey =
+  API_KEY.length > 8
+    ? `${API_KEY.slice(0, 4)}${"*".repeat(API_KEY.length - 8)}${API_KEY.slice(-4)}`
+    : "****";
+
+console.log("[Config] WhatsApp Service iniciando com:");
+console.log(`  PORT             = ${PORT}`);
+console.log(`  API_KEY          = ${maskedKey}`);
+console.log(`  WEBHOOK_URL      = ${WEBHOOK_URL_LOG}`);
+console.log(`  SERVICE_BASE_URL = ${SERVICE_BASE_URL_LOG}`);
+
+// ============================================
 // Middleware
 // ============================================
 


### PR DESCRIPTION
## Problema
O serviço subia normalmente mesmo sem `WHATSAPP_SERVICE_API_KEY`, deixando todas as rotas autenticadas aceitando qualquer request (a validação no middleware retornava 401 para todos, mas o serviço ficava num estado incoerente).

## Solução
- **`process.exit(1)`** imediato no startup se `WHATSAPP_SERVICE_API_KEY` for vazia, com mensagem de erro clara no log.
- Log de todas as configurações ativas ao iniciar (`PORT`, `API_KEY` mascarada, `WEBHOOK_URL`, `SERVICE_BASE_URL`) para facilitar diagnóstico.

## Arquivos alterados
- `whatsapp-service/src/index.ts` — validação e log de config no bloco de inicialização