### PR TITLE
feat(whatsapp-service): rate limiting 30 req/min em /message/send-*

### DIFF
--- a/whatsapp-service/package-lock.json
+++ b/whatsapp-service/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.3.0",
         "qrcode": "^1.5.3"
       },
       "devDependencies": {
@@ -2008,6 +2009,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -2324,6 +2343,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/whatsapp-service/package.json
+++ b/whatsapp-service/package.json
@@ -15,6 +15,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.3.0",
     "qrcode": "^1.5.3"
   },
   "devDependencies": {

--- a/whatsapp-service/src/index.ts
+++ b/whatsapp-service/src/index.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import express from "express";
 import cors from "cors";
+import rateLimit from "express-rate-limit";
 import path from "path";
 import { prisma } from "./lib/prisma.js";
 import { baileysProvider } from "./providers/baileys.provider.js";
@@ -180,8 +181,18 @@ app.post("/instance/:companyId/disconnect", async (req, res) => {
 // Message Routes
 // ============================================
 
+const messageSendLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: "Too many requests. Limit: 30 requests per minute per IP.",
+  },
+});
+
 // POST /message/send-text — Send text message
-app.post("/message/send-text", async (req, res) => {
+app.post("/message/send-text", messageSendLimiter, async (req, res) => {
   try {
     const { companyId, to, content } = req.body;
     if (!companyId || !to || !content) {
@@ -202,7 +213,7 @@ app.post("/message/send-text", async (req, res) => {
 });
 
 // POST /message/send-media — Send media message
-app.post("/message/send-media", async (req, res) => {
+app.post("/message/send-media", messageSendLimiter, async (req, res) => {
   try {
     const { companyId, to, mediaUrl, caption, mediaType } = req.body;
     if (!companyId || !to || !mediaUrl) {


### PR DESCRIPTION
## Problema
As rotas de envio de mensagem não possuíam nenhum controle de taxa, ficando vulneráveis a flood e abuso de API.

## Solução
- Instala `express-rate-limit`
- Cria um limiter compartilhado: **30 req/min por IP**
- Aplica nas rotas `POST /message/send-text` e `POST /message/send-media`
- Retorna `429 Too Many Requests` com mensagem clara ao ultrapassar o limite

## Arquivos alterados
- `whatsapp-service/package.json` — dependência `express-rate-limit`
- `whatsapp-service/package-lock.json`
- `whatsapp-service/src/index.ts` — import + middleware de rate limit