### PR TITLE
fix(whatsapp-service): aviso se WHATSAPP_SERVICE_BASE_URL ausente em produção

### DIFF
--- a/whatsapp-service/src/providers/baileys.provider.ts
+++ b/whatsapp-service/src/providers/baileys.provider.ts
@@ -24,6 +24,17 @@ const SERVICE_PORT = process.env.WHATSAPP_SERVICE_PORT || "3001";
 const SERVICE_BASE_URL =
   process.env.WHATSAPP_SERVICE_BASE_URL || `http://localhost:${SERVICE_PORT}`;
 
+if (
+  !process.env.WHATSAPP_SERVICE_BASE_URL &&
+  process.env.NODE_ENV === "production"
+) {
+  console.warn(
+    "[BaileysProvider] AVISO: WHATSAPP_SERVICE_BASE_URL não está definida. " +
+      `URLs de mídia usarão '${SERVICE_BASE_URL}', que é inacessível externamente. ` +
+      "Defina WHATSAPP_SERVICE_BASE_URL com a URL pública do serviço."
+  );
+}
+
 // ============================================
 // Types
 // ============================================


### PR DESCRIPTION
## Problema
Se `WHATSAPP_SERVICE_BASE_URL` não fosse configurada em produção, as URLs de mídia geradas usariam `http://localhost:PORT`, que é inacessível externamente. O ERP recebia URLs inválidas sem qualquer indicação do problema.

## Solução
Ao inicializar o provider, se `NODE_ENV === 'production'` e a variável não estiver definida, loga um `console.warn` explícito informando:
- que as URLs de mídia usarão localhost (inacessível externamente)
- como corrigir (definir `WHATSAPP_SERVICE_BASE_URL`)

## Arquivos alterados
- `whatsapp-service/src/providers/baileys.provider.ts` — warn no módulo se em produção sem a variável