### PR TITLE
fix(auth): [CRÍTICO] accessToken cookie httpOnly: true — proteção contra XSS

### DIFF
--- a/erp/src/app/api/auth/login/route.ts
+++ b/erp/src/app/api/auth/login/route.ts
@@ -85,9 +85,10 @@ export async function POST(req: NextRequest) {
       },
     });
 
-    // Access token cookie — not httpOnly so middleware can read it
+    // Access token cookie — httpOnly:true protege contra XSS.
+    // O middleware lê via Authorization header (server-side), não via JS.
     response.cookies.set("accessToken", accessToken, {
-      httpOnly: false,
+      httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
       path: "/",


### PR DESCRIPTION
## 🔴 Crítico — httpOnly: false no cookie do accessToken

### Problema
O cookie `accessToken` estava configurado com `httpOnly: false`, tornando o JWT de acesso legível por qualquer JavaScript na página — incluindo scripts injetados via ataques XSS.

**Impacto:** Atacante com XSS conseguia:
1. Ler o token via `document.cookie` ou `fetch`
2. Usar o token para impersonar o usuário em qualquer endpoint autenticado
3. O ataque persiste pelo tempo de vida do token (30 minutos)

### Fix
```diff
- httpOnly: false,  // not httpOnly so middleware can read it
+ httpOnly: true,   // protege contra XSS; middleware lê server-side
```

O `auth-middleware.ts` já extrai o token via `Authorization` header no server-side — não precisa de acesso client-side ao cookie.

### Arquivo alterado
- `src/app/api/auth/login/route.ts`