### PR TITLE
fix(auth): [CRÍTICO] remover fallback hardcoded JWT_SECRET / REFRESH_SECRET

### DIFF
--- a/erp/src/lib/auth.ts
+++ b/erp/src/lib/auth.ts
@@ -2,9 +2,23 @@ import jwt from "jsonwebtoken";
 import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
 
-const JWT_SECRET = process.env.JWT_SECRET || "dev-secret-change-in-production";
-const REFRESH_SECRET =
-  process.env.REFRESH_SECRET || "dev-refresh-secret-change-in-production";
+// Segurança: JWT_SECRET e REFRESH_SECRET NUNCA devem ter fallback hardcoded.
+// Um fallback fixo significa que qualquer pessoa com acesso ao código-fonte pode
+// forjar JWTs válidos e autenticar-se como qualquer usuário do sistema.
+// A aplicação deve falhar no startup se as variáveis não estiverem definidas.
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Variável de ambiente obrigatória não definida: ${name}. ` +
+      `Configure ${name} com um valor seguro de no mínimo 32 caracteres aleatórios.`
+    );
+  }
+  return value;
+}
+
+const JWT_SECRET = requireEnv("JWT_SECRET");
+const REFRESH_SECRET = requireEnv("REFRESH_SECRET");
 
 const ACCESS_TOKEN_EXPIRY = "30m";
 const REFRESH_TOKEN_EXPIRY = "7d";


### PR DESCRIPTION
## 🔴 Crítico — JWT_SECRET com fallback hardcoded

### Problema
```ts
// ANTES — vulnerabilidade crítica:
const JWT_SECRET = process.env.JWT_SECRET || "dev-secret-change-in-production";
```

Com um secret fixo no código-fonte, qualquer pessoa com acesso ao repositório pode:
1. Forjar tokens JWT válidos assinados com o secret conhecido
2. Autenticar-se como qualquer usuário do sistema (incluindo ADMIN)
3. Contornar toda a camada de autenticação sem precisar de credenciais

### Fix
```ts
// DEPOIS — falha explícita no startup:
function requireEnv(name: string): string {
  const value = process.env[name];
  if (!value) throw new Error(`Variável obrigatória não definida: ${name}`);
  return value;
}
const JWT_SECRET = requireEnv("JWT_SECRET");
const REFRESH_SECRET = requireEnv("REFRESH_SECRET");
```

A aplicação agora falha no startup se as variáveis não estiverem configuradas, forçando configuração adequada antes de qualquer requisição.

### Configuração necessária nos ambientes
```bash
JWT_SECRET=$(openssl rand -hex 32)
REFRESH_SECRET=$(openssl rand -hex 32)
```

### Arquivo alterado
- `src/lib/auth.ts`