### PR TITLE
fix(whatsapp-service): CORS com origem configurável via env var

### DIFF
--- a/whatsapp-service/src/index.ts
+++ b/whatsapp-service/src/index.ts
@@ -13,7 +13,11 @@ const API_KEY = process.env.WHATSAPP_SERVICE_API_KEY || "";
 // Middleware
 // ============================================
 
-app.use(cors());
+// WHATSAPP_CORS_ORIGIN: allowed CORS origin (default "*" for dev).
+// In production, set to the specific origin of your ERP frontend/backend,
+// e.g. "https://erp.mendes.app" to block unauthorized cross-origin requests.
+const CORS_ORIGIN = process.env.WHATSAPP_CORS_ORIGIN || "*";
+app.use(cors({ origin: CORS_ORIGIN }));
 app.use(express.json());
 
 // Serve uploaded media files


### PR DESCRIPTION
## Problema
`app.use(cors())` estava com `origin: '*'` hardcoded, permitindo requisições de qualquer origem. Em produção isso expõe a API a requisições cross-origin não autorizadas.

## Solução
Introduz a env var `WHATSAPP_CORS_ORIGIN` (default `'*'` para manter compatibilidade em desenvolvimento). Em produção, basta configurar com a origem do ERP:

```env
WHATSAPP_CORS_ORIGIN=https://erp.mendes.app
```

## Arquivos alterados
- `whatsapp-service/src/index.ts` — leitura da env var + comentário de uso em prod