### PR TITLE
fix(nfse): [CRÍTICO] rpsNumero atômico via FiscalConfig.nfseNextNumber

### DIFF
--- a/erp/src/lib/nfse-actions.ts
+++ b/erp/src/lib/nfse-actions.ts
@@ -143,6 +143,17 @@ export async function emitInvoiceForBoleto(
   // Seleciona o provider NFS-e correto para o município da empresa
   const nfseProvider = await getNfseProviderForCompany(companyId);
 
+  // Gera o número RPS de forma atômica via banco para evitar colisões em
+  // emissões simultâneas. FiscalConfig.nfseNextNumber é incrementado com
+  // uma operação atômica (UPDATE ... SET nfseNextNumber = nfseNextNumber + 1),
+  // garantindo unicidade mesmo sob alta concorrência.
+  const fiscalConfigUpdated = await prisma.fiscalConfig.update({
+    where: { companyId },
+    data: { nfseNextNumber: { increment: 1 } },
+    select: { nfseNextNumber: true },
+  });
+  const rpsNumero = String(fiscalConfigUpdated.nfseNextNumber);
+
   // Guard de idempotência com lock: evita emissão duplicada em requisições concorrentes.
   // Tenta criar o invoice em estado PENDING dentro da transação — se já existir, aborta.
   await prisma.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${`nfse:${boletoId}`}))`;
@@ -171,6 +182,7 @@ export async function emitInvoiceForBoleto(
     serviceDescription,
     value,
     issRate,
+    rpsNumero,
   });
 
   // Create the Invoice record with ISSUED status

--- a/erp/src/lib/nfse.ts
+++ b/erp/src/lib/nfse.ts
@@ -21,6 +21,12 @@ export interface EmitNfseInput {
   serviceDescription: string;
   value: number;
   issRate: number;
+  /**
+   * Número RPS gerado atomicamente via banco (FiscalConfig.nfseNextNumber).
+   * Quando fornecido, os providers devem usá-lo em vez de Date.now().
+   * Evita colisão de numeração em emissões simultâneas.
+   */
+  rpsNumero?: string;
 }
 
 export interface EmitNfseResult {

--- a/erp/src/lib/nfse/campinas.provider.ts
+++ b/erp/src/lib/nfse/campinas.provider.ts
@@ -67,7 +67,11 @@ export class CampinasNfseProvider implements NfseProvider {
 
   async emitNFSe(input: EmitNfseInput): Promise<EmitNfseResult> {
     const hoje = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
-    const rpsNumero = Date.now().toString();
+    // Usar o rpsNumero fornecido (gerado atomicamente via banco) para evitar
+    // colisões em emissões simultâneas. Date.now() como fallback apenas para
+    // compatibilidade com chamadas legadas que não passam o campo.
+    // TODO: remover fallback quando todos os callers passarem rpsNumero.
+    const rpsNumero = input.rpsNumero ?? Date.now().toString();
 
     // Separar CPF e CNPJ do tomador
     const cpfCnpjTomadorRaw = input.clientData.cpfCnpj.replace(/\D/g, "");

--- a/erp/src/lib/nfse/saopaulo.provider.ts
+++ b/erp/src/lib/nfse/saopaulo.provider.ts
@@ -361,7 +361,11 @@ export class SaoPauloNfseProvider implements NfseProvider {
 
   async emitNFSe(input: EmitNfseInput): Promise<EmitNfseResult> {
     const hoje = new Date();
-    const rpsNumero = String(Date.now()).slice(-12);
+    // Usar o rpsNumero fornecido (gerado atomicamente via banco) para evitar
+    // colisões em emissões simultâneas. Date.now() como fallback apenas para
+    // compatibilidade com chamadas legadas que não passam o campo.
+    // TODO: remover fallback quando todos os callers passarem rpsNumero.
+    const rpsNumero = input.rpsNumero ?? String(Date.now()).slice(-12);
     const rpsSerieNumero = "A1";
     const dataEmissaoStr =
       `${hoje.getFullYear()}` +

--- a/erp/src/lib/nfse/taboao.provider.ts
+++ b/erp/src/lib/nfse/taboao.provider.ts
@@ -274,7 +274,11 @@ export class TaboaoDaSerraNfseProvider implements NfseProvider {
   }
 
   async emitNFSe(input: EmitNfseInput): Promise<EmitNfseResult> {
-    const rpsNumero = String(Date.now()).slice(-9);
+    // Usar o rpsNumero fornecido (gerado atomicamente via banco) para evitar
+    // colisões em emissões simultâneas. Date.now() como fallback apenas para
+    // compatibilidade com chamadas legadas que não passam o campo.
+    // TODO: remover fallback quando todos os callers passarem rpsNumero.
+    const rpsNumero = input.rpsNumero ?? String(Date.now()).slice(-9);
 
     const soapBody = buildSoapEnvelope(
       this.codigoUsuario,


### PR DESCRIPTION
## 🔴 Crítico — rpsNumero baseado em Date.now() colide em emissões simultâneas

### Problema
Os três providers NFS-e (Campinas, São Paulo, Taboão) geravam o número do RPS com `Date.now()`. Em emissões simultâneas executando no mesmo milissegundo, produzem **o mesmo número**, causando rejeição pela prefeitura ou duplicação de documento.

### Fix
1. **`EmitNfseInput`** — novo campo opcional `rpsNumero?: string`
2. **`nfse-actions.ts`** — busca o número com incremento atômico PostgreSQL antes de chamar o provider:
   ```ts
   const { nfseNextNumber } = await prisma.fiscalConfig.update({
     where: { companyId },
     data: { nfseNextNumber: { increment: 1 } },
     select: { nfseNextNumber: true },
   });
   ```
3. **Providers** — usam `input.rpsNumero` se fornecido, fallback para `Date.now()` (compatibilidade)

### Garantias
- O `increment` atômico do PostgreSQL garante unicidade mesmo sob alta concorrência
- Número sequencial por empresa (FiscalConfig.nfseNextNumber)
- Sem race condition — o banco serializa os incrementos

### Arquivos alterados
- `src/lib/nfse.ts` (interface)
- `src/lib/nfse-actions.ts` (busca atômica)
- `src/lib/nfse/campinas.provider.ts`
- `src/lib/nfse/saopaulo.provider.ts`
- `src/lib/nfse/taboao.provider.ts`