### PR TITLE
fix(auth): [ALTO] rate limiting no endpoint de login — 10 tentativas/15min por IP

### DIFF
--- a/erp/src/app/api/auth/login/route.ts
+++ b/erp/src/app/api/auth/login/route.ts
@@ -7,8 +7,78 @@ import {
 } from "@/lib/auth";
 import { logAuditEvent } from "@/lib/audit";
 
+// ---------------------------------------------------------------------------
+// Rate limiting simples em memória — protege contra brute force no login.
+// Limite: MAX_ATTEMPTS tentativas por IP em WINDOW_MS milissegundos.
+// Nota: em deploy multi-instância considere Redis ou um middleware externo
+// (ex: Cloudflare Rate Limiting) para compartilhar estado entre réplicas.
+// ---------------------------------------------------------------------------
+
+const MAX_ATTEMPTS = 10;
+const WINDOW_MS = 15 * 60 * 1000; // 15 minutos
+
+interface RateLimitEntry {
+  count: number;
+  windowStart: number;
+}
+
+const loginAttempts = new Map<string, RateLimitEntry>();
+
+// Limpar entradas expiradas periodicamente para evitar memory leak
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of loginAttempts.entries()) {
+    if (now - entry.windowStart > WINDOW_MS) {
+      loginAttempts.delete(ip);
+    }
+  }
+}, WINDOW_MS);
+
+function checkRateLimit(ip: string): { allowed: boolean; retryAfterMs: number } {
+  const now = Date.now();
+  const entry = loginAttempts.get(ip);
+
+  if (!entry || now - entry.windowStart > WINDOW_MS) {
+    // Nova janela
+    loginAttempts.set(ip, { count: 1, windowStart: now });
+    return { allowed: true, retryAfterMs: 0 };
+  }
+
+  if (entry.count >= MAX_ATTEMPTS) {
+    const retryAfterMs = WINDOW_MS - (now - entry.windowStart);
+    return { allowed: false, retryAfterMs };
+  }
+
+  entry.count += 1;
+  return { allowed: true, retryAfterMs: 0 };
+}
+
 export async function POST(req: NextRequest) {
   try {
+    // Extrair IP do cliente para rate limiting
+    const clientIp =
+      req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+      req.headers.get("x-real-ip") ??
+      "unknown";
+
+    const { allowed, retryAfterMs } = checkRateLimit(clientIp);
+    if (!allowed) {
+      const retryAfterSec = Math.ceil(retryAfterMs / 1000);
+      return NextResponse.json(
+        {
+          error: `Muitas tentativas de login. Aguarde ${Math.ceil(retryAfterSec / 60)} minuto(s) antes de tentar novamente.`,
+        },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": String(retryAfterSec),
+            "X-RateLimit-Limit": String(MAX_ATTEMPTS),
+            "X-RateLimit-Window": "900",
+          },
+        }
+      );
+    }
+
     const body = await req.json();
     const { email, password } = body;
 


### PR DESCRIPTION
## 🟠 Alto — Sem rate limiting no login

### Problema
O endpoint `POST /api/auth/login` não tinha nenhum limite de tentativas, permitindo ataques de brute force ilimitados contra qualquer conta de usuário.

### Fix
Rate limiting em memória simples com `Map<IP, {count, windowStart}>`:
- Máximo de **10 tentativas** por IP por janela de **15 minutos**
- Resposta `429 Too Many Requests` com header `Retry-After`
- Limpeza automática de entradas expiradas via `setInterval`
- IP extraído de `x-forwarded-for` / `x-real-ip` (proxy-aware)

```ts
const { allowed, retryAfterMs } = checkRateLimit(clientIp);
if (!allowed) return NextResponse.json({ error: ... }, { status: 429 });
```

### Limitação conhecida (documentada no código)
Em deploy multi-instância, o estado é por réplica. Para proteção centralizada em produção com múltiplas instâncias, considere Redis ou Cloudflare Rate Limiting.

### Arquivo alterado
- `src/app/api/auth/login/route.ts`