### PR TITLE
fix(nfse): [ALTO] bloquear emissão de NFS-e com issRate ≤ 0

### DIFF
--- a/erp/src/lib/nfse-actions.ts
+++ b/erp/src/lib/nfse-actions.ts
@@ -140,6 +140,16 @@ export async function emitInvoiceForBoleto(
   const fiscalConfig = await getCachedFiscalConfig(companyId);
   const issRate = fiscalConfig.issRate;
 
+  // Validação obrigatória: emitir NFS-e com ISS zerado ou negativo é inválido
+  // fiscalmente e pode resultar em multas ou rejeição pela prefeitura.
+  // issRate deve ser > 0 antes de qualquer comunicação com o provider.
+  if (issRate <= 0) {
+    throw new Error(
+      `ISS rate inválido para emissão de NFS-e: ${issRate}%. ` +
+      "Configure a alíquota ISS correta em Configurações → Fiscal antes de emitir notas."
+    );
+  }
+
   // Seleciona o provider NFS-e correto para o município da empresa
   const nfseProvider = await getNfseProviderForCompany(companyId);
 


### PR DESCRIPTION
## 🟠 Alto — issRate = 0 não era bloqueado

### Problema
Nenhuma validação impedia a emissão de NFS-e com alíquota ISS zerada ou negativa. Emitir nota com ISS = 0 sem código de exigibilidade correto (imunidade, isenção, etc.) é fiscalmente inválido e pode resultar em:
- Autuações e multas da Secretaria da Fazenda municipal
- Rejeição do documento pela prefeitura (dependendo do município)
- Documento fiscal com tributação incorreta no histórico

### Fix
```ts
if (issRate <= 0) {
  throw new Error(
    `ISS rate inválido para emissão de NFS-e: ${issRate}%. ` +
    "Configure a alíquota ISS correta em Configurações → Fiscal antes de emitir notas."
  );
}
```

Validação inserida após `getCachedFiscalConfig()` e antes de qualquer comunicação com o provider NFS-e.

### Arquivo alterado
- `src/lib/nfse-actions.ts`