### PR TITLE
fix(nfe): [ALTO] numeração atômica NF-e via FiscalConfig.nfeNextNumber

### DIFF
--- a/erp/prisma/migrations/20260306000001_add_nfe_next_number/migration.sql
+++ b/erp/prisma/migrations/20260306000001_add_nfe_next_number/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: adiciona controle de numeração atômica para NF-e Modelo 55
+ALTER TABLE "fiscal_configs" ADD COLUMN "nfeSerieNumber" TEXT NOT NULL DEFAULT '1';
+ALTER TABLE "fiscal_configs" ADD COLUMN "nfeNextNumber" INTEGER NOT NULL DEFAULT 1;

--- a/erp/prisma/schema.prisma
+++ b/erp/prisma/schema.prisma
@@ -778,6 +778,8 @@ model FiscalConfig {
   codigoMunicipio           String?
   nfseSerieNumber           String    @default("1")
   nfseNextNumber            Int       @default(1)
+  nfeSerieNumber            String    @default("1")
+  nfeNextNumber             Int       @default(1)
   autoEmitNfse              Boolean   @default(false)
   // NFS-e: certificado digital A1 (Campinas e São Paulo)
   certificadoPfx            String?   // base64 do .pfx encriptado via AES

--- a/erp/src/lib/nfe/numero-atomico.ts
+++ b/erp/src/lib/nfe/numero-atomico.ts
@@ -1,0 +1,31 @@
+/**
+ * Controle atômico de numeração para NF-e Modelo 55.
+ *
+ * Usa `UPDATE ... RETURNING` via Prisma para garantir que dois processos
+ * simultâneos nunca recebam o mesmo número — elimina a colisão que ocorreria
+ * com geração client-side (Date.now(), contador em memória, etc.).
+ *
+ * Uso:
+ *   const { nNumber, serie } = await getNextNfeNumber(prisma, companyId);
+ *   await provider.emitNFe({ ..., nNumber, serie });
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+export async function getNextNfeNumber(
+  prisma: PrismaClient,
+  companyId: string
+): Promise<{ nNumber: number; serie: string }> {
+  // Incremento atômico: garante unicidade mesmo sob concorrência
+  const updated = await prisma.fiscalConfig.update({
+    where: { companyId },
+    data: { nfeNextNumber: { increment: 1 } },
+    select: { nfeNextNumber: true, nfeSerieNumber: true },
+  });
+
+  // Após o increment, o valor retornado já é o novo (incrementado)
+  return {
+    nNumber: updated.nfeNextNumber,
+    serie: updated.nfeSerieNumber,
+  };
+}


### PR DESCRIPTION
## Problema\nO número da NF-e era gerado client-side via `Date.now()` em emissões simultâneas. Duas emissões concorrentes podiam gerar o mesmo `nNF`, causando rejeição da SEFAZ.\n\n## Solução\n- Novos campos `nfeNextNumber` e `nfeSerieNumber` no `FiscalConfig`\n- Migration `20260306000001_add_nfe_next_number`\n- Helper `getNextNfeNumber(prisma, companyId)` com `UPDATE ... increment: 1` atômico via Prisma\n- Chamar o helper antes de `emitNFe()` e passar `{ nNumber, serie }` no `EmitNfeInput`