### PR TITLE
fix(nfse): bloquear emissão de NFS-e em boleto não pago

### DIFF
--- a/erp/src/lib/nfse-actions.ts
+++ b/erp/src/lib/nfse-actions.ts
@@ -88,9 +88,10 @@ export async function emitInvoiceForBoleto(
 ): Promise<{ success: true; invoiceId: string; nfNumber: string }> {
   const session = await requireCompanyAccess(companyId);
 
-  // Fetch boleto with related data
+  // Fetch boleto with related data — sem filtro de status para poder
+  // reportar o status real caso o boleto não esteja pago.
   const boleto = await prisma.boleto.findFirst({
-    where: { id: boletoId, companyId, status: "PAID" },
+    where: { id: boletoId, companyId },
     include: {
       proposal: {
         include: {
@@ -124,7 +125,16 @@ export async function emitInvoiceForBoleto(
   });
 
   if (!boleto) {
-    throw new Error("Boleto não encontrado ou não está com status PAID");
+    throw new Error("Boleto não encontrado");
+  }
+
+  // Regra de negócio: NFS-e só pode ser emitida para boletos pagos.
+  // Emitir nota para boleto não quitado gera inconsistência fiscal.
+  if (boleto.status !== "PAID") {
+    throw new Error(
+      "NFS-e só pode ser emitida para boletos pagos. " +
+        `Boleto atual: ${boleto.status}.`
+    );
   }
 
   const client = boleto.proposal.client;


### PR DESCRIPTION
## Problema

Antes, `emitInvoiceForBoleto` buscava o boleto com `WHERE status='PAID'` diretamente na query. Se o boleto existia mas não estava pago, a função retornava a mesma mensagem genérica que quando o boleto não existia — sem feedback útil para o usuário.

## Solução

Separamos a busca da validação:
1. Busca o boleto sem filtro de status
2. Se não encontrado → `'Boleto não encontrado'`
3. Se encontrado mas `status !== 'PAID'` → erro explícito com o status atual:
   `'NFS-e só pode ser emitida para boletos pagos. Boleto atual: GENERATED.'`

## Impacto

- Regra de negócio fiscal preservada: NFS-e só sai para boletos quitados
- Mensagem de erro agora é acionável — o usuário sabe exatamente o que falta
- Sem breaking changes na API

## Arquivos alterados
- `erp/src/lib/nfse-actions.ts`