### PR TITLE
fix(comercial): bloquear geração de boleto em proposta não aceita

### DIFF
--- a/erp/src/app/(app)/comercial/propostas/actions.ts
+++ b/erp/src/app/(app)/comercial/propostas/actions.ts
@@ -512,7 +512,10 @@ export async function generateBoletosForProposal(
     throw new Error("Proposta não encontrada");
   }
   if (proposal.status !== "ACCEPTED") {
-    throw new Error("Somente propostas aceitas podem gerar boletos");
+    throw new Error(
+      "Boletos só podem ser gerados para propostas aceitas. " +
+        `Status atual: ${proposal.status}.`
+    );
   }
   if (proposal.boletos.length > 0) {
     throw new Error("Esta proposta já possui boletos gerados");


### PR DESCRIPTION
## Problema

A mensagem de erro ao tentar gerar boletos para uma proposta não aceita era genérica:
`'Somente propostas aceitas podem gerar boletos'`

Não informava qual era o status atual da proposta, dificultando o diagnóstico pelo usuário.

## Solução

Atualizado o erro para expor o status real:
`'Boletos só podem ser gerados para propostas aceitas. Status atual: DRAFT.'`

A regra de negócio em si já existia e está correta. Este PR melhora apenas o feedback.

## Arquivos alterados
- `erp/src/app/(app)/comercial/propostas/actions.ts`