### PR TITLE
feat(financeiro): confirmação obrigatória com data e observação ao marcar como pago

### DIFF
--- a/erp/src/app/(app)/financeiro/pagar/actions.ts
+++ b/erp/src/app/(app)/financeiro/pagar/actions.ts
@@ -337,7 +337,12 @@ export async function updatePayable(input: UpdatePayableInput) {
   return { id: updated.id };
 }
 
-export async function markPayableAsPaid(id: string, companyId: string) {
+export async function markPayableAsPaid(
+  id: string,
+  companyId: string,
+  paidAt?: Date,
+  notes?: string
+) {
   const session = await requireCompanyAccess(companyId);
 
   const payable = await prisma.accountPayable.findFirst({
@@ -350,11 +355,13 @@ export async function markPayableAsPaid(id: string, companyId: string) {
     throw new Error("Esta conta já foi paga");
   }
 
+  const effectivePaidAt = paidAt ?? new Date();
+
   const updated = await prisma.accountPayable.update({
     where: { id },
     data: {
       status: "PAID",
-      paidAt: new Date(),
+      paidAt: effectivePaidAt,
     },
   });
 
@@ -364,7 +371,11 @@ export async function markPayableAsPaid(id: string, companyId: string) {
     entity: "AccountPayable",
     entityId: id,
     dataBefore: { status: payable.status },
-    dataAfter: { status: "PAID", paidAt: updated.paidAt?.toISOString() },
+    dataAfter: {
+      status: "PAID",
+      paidAt: updated.paidAt?.toISOString(),
+      ...(notes ? { notes } : {}),
+    },
     companyId,
   });
 

--- a/erp/src/app/(app)/financeiro/pagar/page.tsx
+++ b/erp/src/app/(app)/financeiro/pagar/page.tsx
@@ -150,8 +150,14 @@ export default function ContasPagarPage() {
   // Alerts summary
   const [alerts, setAlerts] = useState<PayableAlertSummary | null>(null);
 
-  // Mark as paid
+  // Mark as paid — confirmation dialog
   const [markingId, setMarkingId] = useState<string | null>(null);
+  const [payConfirmOpen, setPayConfirmOpen] = useState(false);
+  const [payConfirmId, setPayConfirmId] = useState<string | null>(null);
+  const [payConfirmDate, setPayConfirmDate] = useState(() =>
+    new Date().toISOString().slice(0, 10)
+  );
+  const [payConfirmNotes, setPayConfirmNotes] = useState("");
 
   const hasActiveFilters =
     filterStatus !== "" ||
@@ -304,12 +310,25 @@ export default function ContasPagarPage() {
   // Mark as paid
   // ---------------------------------------------------
 
-  async function handleMarkAsPaid(id: string) {
-    if (!selectedCompanyId) return;
-    setMarkingId(id);
+  function openPayConfirm(id: string) {
+    setPayConfirmId(id);
+    setPayConfirmDate(new Date().toISOString().slice(0, 10));
+    setPayConfirmNotes("");
+    setPayConfirmOpen(true);
+  }
+
+  async function handleConfirmPayment() {
+    if (!selectedCompanyId || !payConfirmId) return;
+    setMarkingId(payConfirmId);
     try {
-      await markPayableAsPaid(id, selectedCompanyId);
+      await markPayableAsPaid(
+        payConfirmId,
+        selectedCompanyId,
+        new Date(payConfirmDate),
+        payConfirmNotes || undefined
+      );
       toast.success("Conta marcada como paga");
+      setPayConfirmOpen(false);
       await loadPayables();
     } catch (err) {
       toast.error(
@@ -574,7 +593,7 @@ export default function ContasPagarPage() {
                           <Button
                             variant="ghost"
                             size="sm"
-                            onClick={() => handleMarkAsPaid(row.id)}
+                            onClick={() => openPayConfirm(row.id)}
                             disabled={markingId === row.id}
                             title="Marcar como pago (baixa manual)"
                           >
@@ -753,6 +772,68 @@ export default function ContasPagarPage() {
               </Button>
             </DialogFooter>
           </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Payment Confirmation Dialog                                         */}
+      {/* ------------------------------------------------------------------ */}
+      <Dialog open={payConfirmOpen} onOpenChange={setPayConfirmOpen}>
+        <DialogContent className="sm:max-w-[420px]">
+          <DialogHeader>
+            <DialogTitle>Confirmar pagamento</DialogTitle>
+            <DialogDescription>
+              Informe a data do pagamento e, opcionalmente, uma observação ou
+              referência ao comprovante.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="pay-date">
+                Data do pagamento <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="pay-date"
+                type="date"
+                value={payConfirmDate}
+                onChange={(e) => setPayConfirmDate(e.target.value)}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="pay-notes">
+                Observação / comprovante{" "}
+                <span className="text-muted-foreground text-xs">(opcional)</span>
+              </Label>
+              <textarea
+                id="pay-notes"
+                className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                placeholder="Ex: Transferência efetuada, NF #456..."
+                value={payConfirmNotes}
+                onChange={(e) => setPayConfirmNotes(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setPayConfirmOpen(false)}
+              disabled={!!markingId}
+            >
+              Cancelar
+            </Button>
+            <Button
+              className="bg-green-600 hover:bg-green-700 text-white"
+              onClick={handleConfirmPayment}
+              disabled={!payConfirmDate || !!markingId}
+            >
+              <CheckCircle className="mr-2 h-4 w-4" />
+              {markingId ? "Confirmando..." : "Confirmar pagamento"}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/erp/src/app/(app)/financeiro/receber/actions.ts
+++ b/erp/src/app/(app)/financeiro/receber/actions.ts
@@ -172,7 +172,12 @@ export async function createReceivable(input: CreateReceivableInput) {
   return { id: receivable.id };
 }
 
-export async function markReceivableAsPaid(id: string, companyId: string) {
+export async function markReceivableAsPaid(
+  id: string,
+  companyId: string,
+  paidAt?: Date,
+  notes?: string
+) {
   const session = await requireCompanyAccess(companyId);
 
   const receivable = await prisma.accountReceivable.findFirst({
@@ -185,11 +190,13 @@ export async function markReceivableAsPaid(id: string, companyId: string) {
     throw new Error("Esta conta já foi paga");
   }
 
+  const effectivePaidAt = paidAt ?? new Date();
+
   const updated = await prisma.accountReceivable.update({
     where: { id },
     data: {
       status: "PAID",
-      paidAt: new Date(),
+      paidAt: effectivePaidAt,
     },
   });
 
@@ -199,7 +206,11 @@ export async function markReceivableAsPaid(id: string, companyId: string) {
     entity: "AccountReceivable",
     entityId: id,
     dataBefore: { status: receivable.status },
-    dataAfter: { status: "PAID", paidAt: updated.paidAt?.toISOString() },
+    dataAfter: {
+      status: "PAID",
+      paidAt: updated.paidAt?.toISOString(),
+      ...(notes ? { notes } : {}),
+    },
     companyId,
   });
 

--- a/erp/src/app/(app)/financeiro/receber/page.tsx
+++ b/erp/src/app/(app)/financeiro/receber/page.tsx
@@ -117,8 +117,14 @@ export default function ContasReceberPage() {
   const [formValue, setFormValue] = useState("");
   const [formDueDate, setFormDueDate] = useState("");
 
-  // Mark as paid
+  // Mark as paid — confirmation dialog
   const [markingId, setMarkingId] = useState<string | null>(null);
+  const [payConfirmOpen, setPayConfirmOpen] = useState(false);
+  const [payConfirmId, setPayConfirmId] = useState<string | null>(null);
+  const [payConfirmDate, setPayConfirmDate] = useState(() =>
+    new Date().toISOString().slice(0, 10)
+  );
+  const [payConfirmNotes, setPayConfirmNotes] = useState("");
 
   const hasActiveFilters =
     filterStatus !== "" ||
@@ -230,12 +236,25 @@ export default function ContasReceberPage() {
   // Mark as paid
   // ---------------------------------------------------
 
-  async function handleMarkAsPaid(id: string) {
-    if (!selectedCompanyId) return;
-    setMarkingId(id);
+  function openPayConfirm(id: string) {
+    setPayConfirmId(id);
+    setPayConfirmDate(new Date().toISOString().slice(0, 10));
+    setPayConfirmNotes("");
+    setPayConfirmOpen(true);
+  }
+
+  async function handleConfirmPayment() {
+    if (!selectedCompanyId || !payConfirmId) return;
+    setMarkingId(payConfirmId);
     try {
-      await markReceivableAsPaid(id, selectedCompanyId);
+      await markReceivableAsPaid(
+        payConfirmId,
+        selectedCompanyId,
+        new Date(payConfirmDate),
+        payConfirmNotes || undefined
+      );
       toast.success("Conta marcada como paga");
+      setPayConfirmOpen(false);
       await loadReceivables();
     } catch (err) {
       toast.error(
@@ -426,7 +445,7 @@ export default function ContasReceberPage() {
                       <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => handleMarkAsPaid(row.id)}
+                        onClick={() => openPayConfirm(row.id)}
                         disabled={markingId === row.id}
                         title="Marcar como pago (baixa manual)"
                       >
@@ -562,6 +581,68 @@ export default function ContasReceberPage() {
               </Button>
             </DialogFooter>
           </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Payment Confirmation Dialog                                         */}
+      {/* ------------------------------------------------------------------ */}
+      <Dialog open={payConfirmOpen} onOpenChange={setPayConfirmOpen}>
+        <DialogContent className="sm:max-w-[420px]">
+          <DialogHeader>
+            <DialogTitle>Confirmar pagamento</DialogTitle>
+            <DialogDescription>
+              Informe a data do pagamento e, opcionalmente, uma observação ou
+              referência ao comprovante.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="pay-date">
+                Data do pagamento <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="pay-date"
+                type="date"
+                value={payConfirmDate}
+                onChange={(e) => setPayConfirmDate(e.target.value)}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="pay-notes">
+                Observação / comprovante{" "}
+                <span className="text-muted-foreground text-xs">(opcional)</span>
+              </Label>
+              <textarea
+                id="pay-notes"
+                className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                placeholder="Ex: Pix recebido, comprovante #123..."
+                value={payConfirmNotes}
+                onChange={(e) => setPayConfirmNotes(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setPayConfirmOpen(false)}
+              disabled={!!markingId}
+            >
+              Cancelar
+            </Button>
+            <Button
+              className="bg-green-600 hover:bg-green-700 text-white"
+              onClick={handleConfirmPayment}
+              disabled={!payConfirmDate || !!markingId}
+            >
+              <CheckCircle className="mr-2 h-4 w-4" />
+              {markingId ? "Confirmando..." : "Confirmar pagamento"}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
## Problema

Clicar em "Baixar" marcava a conta como paga instantaneamente, sem confirmação e sempre com a data atual — sem espaço para informar a data real do pagamento ou registrar um comprovante.

## Solução

### UI (receber/page.tsx e pagar/page.tsx)
- Ao clicar em "Baixar", abre um **dialog de confirmação** com:
  - **Data do pagamento** (obrigatório, default = hoje)
  - **Observação / comprovante** (opcional, textarea)
  - Botão **"Confirmar pagamento"** (verde) e **"Cancelar"**

### Backend (receber/actions.ts e pagar/actions.ts)
- `markReceivableAsPaid(id, companyId, paidAt?, notes?)`
- `markPayableAsPaid(id, companyId, paidAt?, notes?)`
- `paidAt` é persistido no banco (campo existente)
- `notes` é registrado no log de auditoria (`dataAfter.notes`)

## Sem breaking changes
Os parâmetros `paidAt` e `notes` são opcionais — chamadas existentes continuam funcionando com data = hoje.

## Arquivos alterados
- `erp/src/app/(app)/financeiro/receber/page.tsx`
- `erp/src/app/(app)/financeiro/receber/actions.ts`
- `erp/src/app/(app)/financeiro/pagar/page.tsx`
- `erp/src/app/(app)/financeiro/pagar/actions.ts`