### PR TITLE
feat(comercial): log de atividade na proposta

### DIFF
--- a/erp/prisma/migrations/20260307000001_add_proposal_events/migration.sql
+++ b/erp/prisma/migrations/20260307000001_add_proposal_events/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable: proposal_events
+-- Registra eventos importantes do ciclo de vida da proposta
+-- para auditoria e exibição de timeline ao usuário.
+
+CREATE TABLE IF NOT EXISTS "proposal_events" (
+    "id"          TEXT NOT NULL,
+    "proposalId"  TEXT NOT NULL,
+    "type"        TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "userId"      TEXT,
+    "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "proposal_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "proposal_events_proposalId_createdAt_idx"
+    ON "proposal_events"("proposalId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "proposal_events"
+    ADD CONSTRAINT "proposal_events_proposalId_fkey"
+    FOREIGN KEY ("proposalId")
+    REFERENCES "proposals"("id")
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;

--- a/erp/prisma/schema.prisma
+++ b/erp/prisma/schema.prisma
@@ -598,6 +598,7 @@ model Proposal {
   boletos  Boleto[]
   tickets  Ticket[] @relation("TicketProposal")
   invoices Invoice[]
+  events   ProposalEvent[]
 
   @@index([companyId, status])
   @@map("proposals")
@@ -613,6 +614,20 @@ model ProposalItem {
   proposal Proposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
 
   @@map("proposal_items")
+}
+
+model ProposalEvent {
+  id          String   @id @default(cuid())
+  proposalId  String
+  type        String   // CREATED, EMAIL_SENT, BOLETO_GENERATED, BOLETO_SENT, PAID, NFSE_EMITTED, STATUS_CHANGED
+  description String
+  userId      String?
+  createdAt   DateTime @default(now())
+
+  proposal Proposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+
+  @@index([proposalId, createdAt])
+  @@map("proposal_events")
 }
 
 model Boleto {

--- a/erp/src/app/(app)/comercial/propostas/[id]/page.tsx
+++ b/erp/src/app/(app)/comercial/propostas/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { ArrowLeft, FileText, Mail, Receipt } from "lucide-react";
+import { ArrowLeft, FileText, Mail, Receipt, CheckCircle2, Send, FileCheck, AlertCircle, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -35,8 +35,10 @@ import {
   getProposalById,
   listBoletosForProposal,
   generateBoletosForProposal,
+  listProposalEvents,
   type ProposalDetail,
   type BoletoRow,
+  type ProposalEventRow,
 } from "../actions";
 import {
   sendProposalEmail,
@@ -139,6 +141,7 @@ export default function ProposalDetailPage() {
 
   const [proposal, setProposal] = useState<ProposalDetail | null>(null);
   const [boletos, setBoletos] = useState<BoletoRow[]>([]);
+  const [events, setEvents] = useState<ProposalEventRow[]>([]);
   const [loading, setLoading] = useState(true);
 
   // Generate boleto dialog
@@ -169,12 +172,14 @@ export default function ProposalDetailPage() {
     if (!selectedCompanyId || !proposalId) return;
     setLoading(true);
     try {
-      const [proposalData, boletosData] = await Promise.all([
+      const [proposalData, boletosData, eventsData] = await Promise.all([
         getProposalById(proposalId, selectedCompanyId),
         listBoletosForProposal(proposalId, selectedCompanyId),
+        listProposalEvents(proposalId, selectedCompanyId),
       ]);
       setProposal(proposalData);
       setBoletos(boletosData);
+      setEvents(eventsData);
     } catch (err) {
       toast.error(
         err instanceof Error ? err.message : "Erro ao carregar proposta"
@@ -588,6 +593,47 @@ export default function ProposalDetailPage() {
           </CardContent>
         )}
       </Card>
+
+      {/* Activity Log */}
+      {events.length > 0 && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              <Clock className="h-4 w-4 text-muted-foreground" />
+              Histórico de atividades
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ol className="relative border-l border-muted-foreground/20 ml-3 space-y-4">
+              {events.map((evt) => (
+                <li key={evt.id} className="ml-4">
+                  <div className="absolute -left-[7px] mt-0.5 h-3.5 w-3.5 rounded-full border-2 border-background bg-muted-foreground/30 flex items-center justify-center">
+                    {evt.type === "CREATED" && <CheckCircle2 className="h-2 w-2 text-green-600" />}
+                    {evt.type === "EMAIL_SENT" && <Send className="h-2 w-2 text-blue-600" />}
+                    {evt.type === "BOLETO_GENERATED" && <FileText className="h-2 w-2 text-purple-600" />}
+                    {evt.type === "BOLETO_SENT" && <Send className="h-2 w-2 text-indigo-600" />}
+                    {evt.type === "PAID" && <CheckCircle2 className="h-2 w-2 text-green-600" />}
+                    {evt.type === "NFSE_EMITTED" && <FileCheck className="h-2 w-2 text-teal-600" />}
+                    {evt.type === "STATUS_CHANGED" && <AlertCircle className="h-2 w-2 text-orange-600" />}
+                  </div>
+                  <div className="pl-1">
+                    <p className="text-sm text-foreground leading-snug">{evt.description}</p>
+                    <time className="text-xs text-muted-foreground">
+                      {new Intl.DateTimeFormat("pt-BR", {
+                        day: "2-digit",
+                        month: "2-digit",
+                        year: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      }).format(new Date(evt.createdAt))}
+                    </time>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Generate Boletos Dialog */}
       <Dialog open={generateDialogOpen} onOpenChange={setGenerateDialogOpen}>

--- a/erp/src/app/(app)/comercial/propostas/actions.ts
+++ b/erp/src/app/(app)/comercial/propostas/actions.ts
@@ -10,6 +10,26 @@ import { getCachedFiscalConfig } from "@/app/(app)/configuracoes/fiscal/actions"
 import { emitInvoiceForBoleto } from "@/lib/nfse-actions";
 
 // ---------------------------------------------------------------------------
+// Proposal Event Helper
+// ---------------------------------------------------------------------------
+
+async function createProposalEvent(
+  proposalId: string,
+  type: string,
+  description: string,
+  userId?: string
+) {
+  try {
+    await prisma.proposalEvent.create({
+      data: { proposalId, type, description, userId },
+    });
+  } catch (err) {
+    // Não propagar erro de log — o evento principal não deve falhar por causa do log
+    console.error("[ProposalEvent] Falha ao registrar evento:", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -273,6 +293,13 @@ export async function createProposal(
     companyId,
   });
 
+  await createProposalEvent(
+    proposal.id,
+    "CREATED",
+    `Proposta criada com ${proposal.items.length} item(s). Valor total: R$ ${proposal.totalValue}.`,
+    session.userId
+  );
+
   return { id: proposal.id };
 }
 
@@ -427,6 +454,13 @@ export async function updateProposalStatus(
     dataAfter: { status: newStatus },
     companyId,
   });
+
+  await createProposalEvent(
+    proposalId,
+    "STATUS_CHANGED",
+    `Status alterado: ${proposal.status} → ${newStatus}.`,
+    session.userId
+  );
 
   return { success: true };
 }
@@ -606,6 +640,13 @@ export async function generateBoletosForProposal(
     companyId: input.companyId,
   });
 
+  await createProposalEvent(
+    input.proposalId,
+    "BOLETO_GENERATED",
+    `${createdBoletos.length} boleto(s) gerado(s) no valor total de R$ ${totalValue.toFixed(2)}.`,
+    session.userId
+  );
+
   return { boletos: createdBoletos };
 }
 
@@ -675,6 +716,23 @@ export async function updateBoletoStatus(
     companyId,
   });
 
+  // Registrar evento de log na proposta
+  if (newStatus === "PAID") {
+    await createProposalEvent(
+      boleto.proposalId,
+      "PAID",
+      `Boleto #${boleto.installmentNumber} marcado como pago (R$ ${boleto.value}).`,
+      session.userId
+    );
+  } else if (newStatus === "SENT") {
+    await createProposalEvent(
+      boleto.proposalId,
+      "BOLETO_SENT",
+      `Boleto #${boleto.installmentNumber} marcado como enviado.`,
+      session.userId
+    );
+  }
+
   // Auto-emit NFS-e when boleto is paid
   if (newStatus === "PAID") {
     try {
@@ -725,4 +783,36 @@ export async function updateBoletoStatus(
   }
 
   return { success: true };
+}
+
+// ---------------------------------------------------------------------------
+// Proposal Events
+// ---------------------------------------------------------------------------
+
+export interface ProposalEventRow {
+  id: string;
+  type: string;
+  description: string;
+  userId: string | null;
+  createdAt: string;
+}
+
+export async function listProposalEvents(
+  proposalId: string,
+  companyId: string
+): Promise<ProposalEventRow[]> {
+  await requireCompanyAccess(companyId);
+
+  const events = await prisma.proposalEvent.findMany({
+    where: { proposalId, proposal: { companyId } },
+    orderBy: { createdAt: "asc" },
+  });
+
+  return events.map((e) => ({
+    id: e.id,
+    type: e.type,
+    description: e.description,
+    userId: e.userId,
+    createdAt: e.createdAt.toISOString(),
+  }));
 }

--- a/erp/src/lib/email-actions.ts
+++ b/erp/src/lib/email-actions.ts
@@ -257,6 +257,20 @@ export async function sendProposalEmail(
     companyId,
   });
 
+  // Registrar evento na proposta
+  try {
+    await prisma.proposalEvent.create({
+      data: {
+        proposalId: proposal.id,
+        type: "EMAIL_SENT",
+        description: `Proposta enviada por e-mail para ${proposal.client.email}.`,
+        userId: session.userId,
+      },
+    });
+  } catch (eventErr) {
+    console.error("[ProposalEvent] Falha ao registrar evento EMAIL_SENT:", eventErr);
+  }
+
   return { success: true };
 }
 
@@ -387,6 +401,20 @@ export async function sendBoletoEmail(
     } as unknown as Prisma.InputJsonValue,
     companyId,
   });
+
+  // Registrar evento na proposta
+  try {
+    await prisma.proposalEvent.create({
+      data: {
+        proposalId: boleto.proposalId,
+        type: "BOLETO_SENT",
+        description: `Boleto #${boleto.installmentNumber} enviado por e-mail para ${client.email}.`,
+        userId: session.userId,
+      },
+    });
+  } catch (eventErr) {
+    console.error("[ProposalEvent] Falha ao registrar evento BOLETO_SENT:", eventErr);
+  }
 
   return { success: true };
 }

--- a/erp/src/lib/nfse-actions.ts
+++ b/erp/src/lib/nfse-actions.ts
@@ -345,6 +345,20 @@ export async function emitInvoiceForBoleto(
     }
   }
 
+  // Registrar evento na proposta (best-effort — não falhar se der erro)
+  try {
+    await prisma.proposalEvent.create({
+      data: {
+        proposalId: boleto.proposal.id,
+        type: "NFSE_EMITTED",
+        description: `NFS-e emitida: número ${result.nfNumber}. Valor: R$ ${value.toFixed(2)}.`,
+        userId: session.userId,
+      },
+    });
+  } catch (eventErr) {
+    console.error("[ProposalEvent] Falha ao registrar evento NFSE_EMITTED:", eventErr);
+  }
+
   return {
     success: true,
     invoiceId: invoice.id,


### PR DESCRIPTION
## Problema

Não havia rastreamento do que acontecia com uma proposta após sua criação — sem saber quando foi enviada, quando boletos foram gerados, quando o cliente pagou, etc.

## Solução

### Schema (novo modelo)
```prisma
model ProposalEvent {
  id          String   @id @default(cuid())
  proposalId  String
  type        String   // CREATED, EMAIL_SENT, BOLETO_GENERATED, BOLETO_SENT, PAID, NFSE_EMITTED, STATUS_CHANGED
  description String
  userId      String?
  createdAt   DateTime @default(now())

  proposal Proposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
}
```

### Migration
`prisma/migrations/20260307000001_add_proposal_events/migration.sql` com `IF NOT EXISTS`

### Eventos registrados
| Tipo | Quando |
|------|--------|
| CREATED | Ao criar a proposta |
| STATUS_CHANGED | Ao mudar qualquer status |
| EMAIL_SENT | Ao enviar proposta por e-mail |
| BOLETO_GENERATED | Ao gerar boletos |
| BOLETO_SENT | Ao enviar boleto por e-mail |
| PAID | Ao marcar boleto como pago |
| NFSE_EMITTED | Ao emitir NFS-e |

### UI — Timeline na página de detalhe
- Lista cronológica de eventos com data/hora, ícone por tipo e descrição
- Só renderizada se houver eventos (sem poluição visual em propostas novas)

### Estratégia de logging
- Todos os logs são **best-effort** — envolvidos em try/catch
- O evento principal nunca falha por causa do log de auditoria

## Arquivos alterados
- `prisma/schema.prisma`
- `prisma/migrations/20260307000001_add_proposal_events/migration.sql`
- `src/app/(app)/comercial/propostas/actions.ts`
- `src/app/(app)/comercial/propostas/[id]/page.tsx`
- `src/lib/nfse-actions.ts`
- `src/lib/email-actions.ts`