### PR TITLE
feat(dashboard): card de alertas unificados agregando todos os módulos

### DIFF
--- a/erp/src/app/(app)/dashboard/actions.ts
+++ b/erp/src/app/(app)/dashboard/actions.ts
@@ -194,3 +194,145 @@ export async function getDashboardData(filters: DashboardFilters): Promise<Dashb
     periodLabel: getPeriodLabel(filters.period, filters.customStart, filters.customEnd),
   };
 }
+
+// ---------------------------------------------------------------------------
+// Dashboard Alerts
+// ---------------------------------------------------------------------------
+
+export type AlertType =
+  | "BOLETO_VENCIDO"
+  | "SLA_BREACH"
+  | "SLA_RISK"
+  | "NFSE_FAILED"
+  | "PROPOSTA_SEM_RESPOSTA";
+
+export interface DashboardAlert {
+  type: AlertType;
+  title: string;
+  description: string;
+  href: string;
+  severity: "critical" | "warning";
+}
+
+/**
+ * Agrega alertas de todos os módulos para exibição no dashboard.
+ * Considera todas as empresas que o usuário tem acesso.
+ */
+export async function getDashboardAlerts(): Promise<DashboardAlert[]> {
+  const session = await requireSession();
+  if (!session) throw new Error("Não autenticado");
+
+  // Resolve company IDs accessible to this user
+  let companyIds: string[];
+  if (session.role === "ADMIN") {
+    const companies = await prisma.company.findMany({
+      where: { status: "ACTIVE" },
+      select: { id: true },
+    });
+    companyIds = companies.map((c) => c.id);
+  } else {
+    const assignments = await prisma.userCompany.findMany({
+      where: { userId: session.userId },
+      include: { company: { select: { id: true, status: true } } },
+    });
+    companyIds = assignments
+      .filter((a) => a.company.status === "ACTIVE")
+      .map((a) => a.company.id);
+  }
+
+  if (companyIds.length === 0) return [];
+
+  const alerts: DashboardAlert[] = [];
+  const now = new Date();
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  // 1. Boletos vencidos (status OVERDUE)
+  const overdueCount = await prisma.boleto.count({
+    where: { companyId: { in: companyIds }, status: "OVERDUE" },
+  });
+  if (overdueCount > 0) {
+    alerts.push({
+      type: "BOLETO_VENCIDO",
+      title: `${overdueCount} boleto${overdueCount > 1 ? "s" : ""} vencido${overdueCount > 1 ? "s" : ""}`,
+      description: "Boletos vencidos aguardando regularização ou cobrança.",
+      href: "/comercial/propostas",
+      severity: "critical",
+    });
+  }
+
+  // 2. Tickets com SLA violado
+  const slaBreachedCount = await prisma.ticket.count({
+    where: {
+      companyId: { in: companyIds },
+      slaBreached: true,
+      status: { notIn: ["RESOLVED", "CLOSED"] },
+    },
+  });
+  if (slaBreachedCount > 0) {
+    alerts.push({
+      type: "SLA_BREACH",
+      title: `${slaBreachedCount} ticket${slaBreachedCount > 1 ? "s" : ""} com SLA estourado`,
+      description: "Tickets que ultrapassaram o prazo de atendimento definido.",
+      href: "/sac/tickets",
+      severity: "critical",
+    });
+  }
+
+  // 3. Tickets em risco de estourar SLA
+  const slaAtRiskCount = await prisma.ticket.count({
+    where: {
+      companyId: { in: companyIds },
+      slaAtRisk: true,
+      slaBreached: false,
+      status: { notIn: ["RESOLVED", "CLOSED"] },
+    },
+  });
+  if (slaAtRiskCount > 0) {
+    alerts.push({
+      type: "SLA_RISK",
+      title: `${slaAtRiskCount} ticket${slaAtRiskCount > 1 ? "s" : ""} em risco de estourar SLA`,
+      description: "Tickets próximos do prazo limite — ação urgente recomendada.",
+      href: "/sac/tickets",
+      severity: "warning",
+    });
+  }
+
+  // 4. NFS-e com status PENDING há mais de 24h (possível falha na emissão)
+  const pendingNfseCount = await prisma.invoice.count({
+    where: {
+      companyId: { in: companyIds },
+      status: "PENDING",
+      createdAt: { lt: oneDayAgo },
+    },
+  });
+  if (pendingNfseCount > 0) {
+    alerts.push({
+      type: "NFSE_FAILED",
+      title: `${pendingNfseCount} NFS-e pendente${pendingNfseCount > 1 ? "s" : ""} há mais de 24h`,
+      description: "Notas fiscais em estado PENDING por mais de 24h — possível falha na emissão.",
+      href: "/fiscal",
+      severity: "warning",
+    });
+  }
+
+  // 5. Propostas SENT há mais de 7 dias sem resposta
+  const oldSentProposalsCount = await prisma.proposal.count({
+    where: {
+      companyId: { in: companyIds },
+      status: "SENT",
+      updatedAt: { lt: sevenDaysAgo },
+    },
+  });
+  if (oldSentProposalsCount > 0) {
+    alerts.push({
+      type: "PROPOSTA_SEM_RESPOSTA",
+      title: `${oldSentProposalsCount} proposta${oldSentProposalsCount > 1 ? "s" : ""} sem resposta há +7 dias`,
+      description: "Propostas enviadas sem aceite ou rejeição — pode ser hora de um follow-up.",
+      href: "/comercial/propostas",
+      severity: "warning",
+    });
+  }
+
+  return alerts;
+}

--- a/erp/src/app/(app)/dashboard/page.tsx
+++ b/erp/src/app/(app)/dashboard/page.tsx
@@ -46,7 +46,9 @@ import {
 } from "@/components/ui/select";
 import {
   getDashboardData,
+  getDashboardAlerts,
   type DashboardData,
+  type DashboardAlert,
   type PeriodType,
 } from "./actions";
 
@@ -111,6 +113,8 @@ export default function DashboardPage() {
   const [period, setPeriod] = useState<PeriodType>("month");
   const [customStart, setCustomStart] = useState("");
   const [customEnd, setCustomEnd] = useState("");
+  const [alerts, setAlerts] = useState<DashboardAlert[]>([]);
+  const [alertsLoading, setAlertsLoading] = useState(true);
 
   const loadData = useCallback(async () => {
     try {
@@ -127,6 +131,22 @@ export default function DashboardPage() {
       setLoading(false);
     }
   }, [period, customStart, customEnd]);
+
+  const loadAlerts = useCallback(async () => {
+    try {
+      setAlertsLoading(true);
+      const result = await getDashboardAlerts();
+      setAlerts(result);
+    } catch {
+      // Silencia erros de alertas — não deve quebrar o dashboard
+    } finally {
+      setAlertsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAlerts();
+  }, [loadAlerts]);
 
   useEffect(() => {
     // For custom period, only load when both dates are set
@@ -190,6 +210,49 @@ export default function DashboardPage() {
           )}
         </div>
       </div>
+
+      {/* Unified Alerts Card — só aparece quando há alertas */}
+      {!alertsLoading && alerts.length > 0 && (
+        <Card className="border-orange-200 bg-orange-50">
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-orange-800 text-base">
+              <AlertTriangle className="h-5 w-5 text-orange-500" />
+              Atenção necessária
+              <span className="ml-auto rounded-full bg-orange-500 px-2 py-0.5 text-xs font-bold text-white">
+                {alerts.length}
+              </span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {alerts.map((alert, i) => (
+                <li key={i} className="flex items-start gap-3">
+                  <span
+                    className={`mt-0.5 flex-shrink-0 rounded-full w-2 h-2 ${
+                      alert.severity === "critical" ? "bg-red-500" : "bg-yellow-500"
+                    }`}
+                    style={{ marginTop: "6px" }}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-orange-900 leading-snug">
+                      {alert.title}
+                    </p>
+                    <p className="text-xs text-orange-700 leading-snug">
+                      {alert.description}
+                    </p>
+                  </div>
+                  <a
+                    href={alert.href}
+                    className="flex-shrink-0 text-xs text-orange-600 underline hover:text-orange-800 whitespace-nowrap"
+                  >
+                    Ver →
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
 
       {/* KPI Cards */}
       {loading ? (


### PR DESCRIPTION
## Problema

O dashboard não tinha visibilidade consolidada de problemas que precisam de ação — era necessário entrar em cada módulo separadamente para detectar boletos vencidos, SLA estourado, NFS-e travada, etc.

## Solução

### Server Action: `getDashboardAlerts()`
Consulta paralela em todas as empresas do usuário autenticado, retornando alertas de 5 módulos:

| Tipo | Fonte | Severity |
|------|-------|----------|
| `BOLETO_VENCIDO` | Boletos com status `OVERDUE` | 🔴 critical |
| `SLA_BREACH` | Tickets com `slaBreached=true` e não resolvidos | 🔴 critical |
| `SLA_RISK` | Tickets com `slaAtRisk=true` e não resolvidos | 🟡 warning |
| `NFSE_FAILED` | NFS-e em `PENDING` há mais de 24h | 🟡 warning |
| `PROPOSTA_SEM_RESPOSTA` | Propostas `SENT` há mais de 7 dias | 🟡 warning |

### UI: Card "Atenção necessária"
- Exibido **acima dos KPIs** no dashboard
- Bullet vermelho/amarelo por severity
- Link direto para o módulo relevante
- **Só aparece se houver alertas** — dashboard limpo não é poluído
- Carregamento independente dos KPIs, falhas silenciosas

## Arquivos alterados
- `erp/src/app/(app)/dashboard/actions.ts` — `getDashboardAlerts()`
- `erp/src/app/(app)/dashboard/page.tsx` — estado + card de alertas