### PR TITLE
refactor(payment): unify PROVIDER_TYPES — remove duplicate from types.ts

### DIFF
--- a/erp/src/lib/payment/__tests__/types.test.ts
+++ b/erp/src/lib/payment/__tests__/types.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { isProviderType, PROVIDER_TYPES, MOCK_PROVIDER } from "@/lib/payment/types";
+import { isProviderType, MOCK_PROVIDER } from "@/lib/payment/types";
+import {
+  PROVIDER_TYPES,
+  PRODUCTION_PROVIDER_TYPES,
+} from "@/lib/payment/constants";
 
 describe("isProviderType()", () => {
   it("retorna true para cada provider de produção", () => {
-    for (const p of PROVIDER_TYPES) {
+    for (const p of PRODUCTION_PROVIDER_TYPES) {
       expect(isProviderType(p)).toBe(true);
     }
   });
@@ -33,14 +37,25 @@ describe("isProviderType()", () => {
   });
 });
 
-describe("PROVIDER_TYPES (array canônico de produção)", () => {
-  it("não inclui mock (mock não deve ser persistido no banco em produção)", () => {
-    expect(PROVIDER_TYPES).not.toContain("mock");
-  });
-
-  it("inclui pagarme e pinbank", () => {
+describe("PROVIDER_TYPES (from constants.ts — environment-aware)", () => {
+  it("inclui pagarme e pinbank em qualquer ambiente", () => {
     expect(PROVIDER_TYPES).toContain("pagarme");
     expect(PROVIDER_TYPES).toContain("pinbank");
+  });
+
+  it("PRODUCTION_PROVIDER_TYPES não inclui mock", () => {
+    expect(PRODUCTION_PROVIDER_TYPES).not.toContain("mock");
+  });
+
+  it("PRODUCTION_PROVIDER_TYPES inclui pagarme e pinbank", () => {
+    expect(PRODUCTION_PROVIDER_TYPES).toContain("pagarme");
+    expect(PRODUCTION_PROVIDER_TYPES).toContain("pinbank");
+  });
+
+  // In test environment, PROVIDER_TYPES should include mock (DEV_PROVIDER_TYPES)
+  it("em ambiente de teste, PROVIDER_TYPES inclui mock", () => {
+    expect(process.env.NODE_ENV).not.toBe("production");
+    expect(PROVIDER_TYPES).toContain("mock");
   });
 });
 

--- a/erp/src/lib/payment/types.ts
+++ b/erp/src/lib/payment/types.ts
@@ -1,9 +1,12 @@
 // ============================================================
-// Provider Types — lista canônica dos providers suportados
+// Provider Types — type definitions for payment providers
 // ============================================================
+// NOTE: The canonical PROVIDER_TYPES array lives in constants.ts.
+// This file only exports types, the MOCK_PROVIDER constant, and
+// the isProviderType() type guard.
+// See: https://github.com/diogenesmendes01/MendesAplication/issues/117
 
-/** Providers de produção — únicos valores válidos para registros no banco. */
-export const PROVIDER_TYPES = ["pagarme", "pinbank"] as const;
+import { PRODUCTION_PROVIDER_TYPES } from "./constants";
 
 /**
  * Provider de mock — usado exclusivamente como fallback interno em ambiente
@@ -12,7 +15,11 @@ export const PROVIDER_TYPES = ["pagarme", "pinbank"] as const;
  */
 export const MOCK_PROVIDER = "mock" as const;
 
-export type ProviderType = (typeof PROVIDER_TYPES)[number] | typeof MOCK_PROVIDER;
+/**
+ * Union type of all valid provider identifiers.
+ * Derived from PRODUCTION_PROVIDER_TYPES (constants.ts) + MOCK_PROVIDER.
+ */
+export type ProviderType = (typeof PRODUCTION_PROVIDER_TYPES)[number] | typeof MOCK_PROVIDER;
 
 /**
  * Type guard para narrowing em runtime: verifica se um valor lido do banco
@@ -22,10 +29,10 @@ export type ProviderType = (typeof PROVIDER_TYPES)[number] | typeof MOCK_PROVIDE
  * com mensagem clara para dados legados ou corrompidos.
  *
  * Nota: "mock" é aceito pois pode ser usado como fallback interno (ver propostas/actions.ts).
- * Valores de DB deveriam constar apenas em PROVIDER_TYPES (produção).
+ * Valores de DB deveriam constar apenas em PRODUCTION_PROVIDER_TYPES (produção).
  */
 export function isProviderType(v: string): v is ProviderType {
-  return (PROVIDER_TYPES as readonly string[]).includes(v) || v === MOCK_PROVIDER;
+  return (PRODUCTION_PROVIDER_TYPES as readonly string[]).includes(v) || v === MOCK_PROVIDER;
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
Removes the duplicate `PROVIDER_TYPES` from `types.ts` that was a static copy of the environment-aware version in `constants.ts`.

### Problem
Two exports named `PROVIDER_TYPES` with different semantics:
- `types.ts`: static array `["pagarme", "pinbank"]` — always production only
- `constants.ts`: conditional based on `NODE_ENV` — includes mock in dev/test

Tests imported from `types.ts` (static), so the test "não inclui mock" always passed regardless of bugs in the conditional logic.

### Solution
- Removed `PROVIDER_TYPES` export from `types.ts`
- `ProviderType` now derives from `PRODUCTION_PROVIDER_TYPES` imported from `constants.ts`
- `isProviderType()` uses the same canonical source
- Tests updated to import from correct paths and verify conditional behavior

All 158 tests pass ✅

Closes #117