### PR TITLE
refactor(ai): add fallback pricing warning + last-verified date

### DIFF
--- a/erp/src/lib/ai/agent.ts
+++ b/erp/src/lib/ai/agent.ts
@@ -8,7 +8,7 @@ import { executeTool } from "./tool-executor";
 import type { ToolContext } from "./tool-executor";
 import { decrypt } from "@/lib/encryption";
 import { getTodaySpend, logUsage } from "./cost-tracker";
-import { MODEL_PRICING, DEFAULT_MODELS } from "./pricing";
+import { MODEL_PRICING, FALLBACK_PRICING, DEFAULT_MODELS } from "./pricing";
 import { getBrlUsdRateSync } from "./exchange-rate";
 
 // ─── Result types ─────────────────────────────────────────────────────────────
@@ -646,7 +646,7 @@ function estimateCostBrl(
   inputTokens: number,
   outputTokens: number
 ): number {
-  const pricing = MODEL_PRICING[model] ?? { input: 1.0, output: 3.0 };
+  const pricing = MODEL_PRICING[model] ?? FALLBACK_PRICING;
   const costUsd =
     (inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000;
   return costUsd * getBrlUsdRateSync();

--- a/erp/src/lib/ai/cost-tracker.ts
+++ b/erp/src/lib/ai/cost-tracker.ts
@@ -30,6 +30,14 @@ interface LogUsageParams {
 export async function logUsage(params: LogUsageParams) {
   const pricing = MODEL_PRICING[params.model] ?? FALLBACK_PRICING;
 
+  if (!MODEL_PRICING[params.model]) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[cost-tracker] Unknown model "${params.model}" — using FALLBACK_PRICING. ` +
+      `Update MODEL_PRICING in pricing.ts to track costs accurately.`
+    );
+  }
+
   const costUsd =
     (params.inputTokens * pricing.input +
       params.outputTokens * pricing.output) /

--- a/erp/src/lib/ai/pricing.ts
+++ b/erp/src/lib/ai/pricing.ts
@@ -1,6 +1,8 @@
 // ─── Pricing table (USD per 1M tokens) ───────────────────────────────────────
 // Update prices when providers change their rates.
 // Source: each provider's pricing page.
+// Last verified: 2026-03-16
+// Review schedule: quarterly (next: 2026-06-16)
 // This file has NO "use server" directive — constants are importable anywhere.
 
 export interface ModelPricing {
@@ -32,7 +34,11 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   "deepseek-reasoner": { input: 0.55, output: 2.19 },
 };
 
-// Fallback pricing for unknown models
+// Fallback pricing for unknown models.
+// ⚠️ WARNING: When a model is not in MODEL_PRICING, cost-tracker.ts will
+// log a warning and use this generic fallback. Add new models to
+// MODEL_PRICING to track costs accurately.
+// See: https://github.com/diogenesmendes01/MendesAplication/issues/128
 export const FALLBACK_PRICING: ModelPricing = { input: 1.0, output: 3.0 };
 
 /**


### PR DESCRIPTION
## Summary
Makes silent fallback pricing visible and adds maintenance documentation.

### Changes
- **`cost-tracker.ts`**: Logs warning when a model is not found in `MODEL_PRICING` and falls back to generic pricing
- **`pricing.ts`**: Added last-verified date (2026-03-16), quarterly review schedule, and documentation about fallback behavior
- **`agent.ts`**: `estimateCostBrl()` now uses `FALLBACK_PRICING` constant instead of inline duplicate values

### Why
Previously, when a new model was used that wasn't in `MODEL_PRICING`, it would silently use generic fallback costs — leading to inaccurate cost tracking without any visibility.

All 156 tests pass ✅

Closes #128