### PR TITLE
fix: standardize prisma generate invocation (#312)

### DIFF
--- a/erp/package.json
+++ b/erp/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "postinstall": "npx prisma generate --schema=./prisma/schema.prisma || true",
+    "postinstall": "npx prisma generate",
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "npx prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "workers": "npx tsx src/lib/workers/index.ts",


### PR DESCRIPTION
## Changes

Standardized `prisma generate` invocation in `erp/package.json`:

| Script | Before | After |
|--------|--------|-------|
| `postinstall` | `npx prisma generate --schema=./prisma/schema.prisma \|\| true` | `npx prisma generate` |
| `build` | `prisma generate && next build` | `npx prisma generate && next build` |

### What was fixed:
- **`npx` vs bare `prisma`**: Both now use `npx prisma generate` (ensures local binary)
- **`--schema` flag**: Removed — Prisma auto-detects from default `prisma/schema.prisma` location
- **`|| true`**: Removed from postinstall — errors should surface, not be silently swallowed

Fixes diogenesmendes01/MendesAplication#312