### PR TITLE
fix(ai): replace in-memory rate limiters with Redis-backed counters

### DIFF
--- a/erp/src/app/(app)/configuracoes/ai/actions.ts
+++ b/erp/src/app/(app)/configuracoes/ai/actions.ts
@@ -78,23 +78,33 @@ function maskApiKey(key: string | null | undefined, hint?: string | null): strin
 }
 
 // ---------------------------------------------------------------------------
-// Rate limiters — uses RateLimiter interface (currently in-memory).
-// See: https://github.com/diogenesmendes01/MendesAplication/issues/124
-// Swap to Redis-backed implementation when available via createRateLimiter().
+// Rate limiters — Redis-backed with in-memory fallback.
+// Keys: rate:simulate:{companyId}, rate:testconn:{companyId} (TTL 60s)
+// See: https://github.com/diogenesmendes01/MendesAplication/issues/310
 // ---------------------------------------------------------------------------
 
-import { createRateLimiter } from "@/lib/rate-limiter";
+import { createAsyncRateLimiter } from "@/lib/rate-limiter";
 
-const testConnectionLimiter = createRateLimiter({ limit: 5, windowMs: 60_000 });
+const testConnectionLimiter = createAsyncRateLimiter({
+  limit: 5,
+  windowMs: 60_000,
+  prefix: "rate:testconn",
+});
 
-function checkTestConnectionRateLimit(companyId: string): boolean {
-  return testConnectionLimiter.check(companyId).allowed;
+async function checkTestConnectionRateLimit(companyId: string): Promise<boolean> {
+  const result = await testConnectionLimiter.check(companyId);
+  return result.allowed;
 }
 
-const simulationLimiter = createRateLimiter({ limit: 10, windowMs: 60_000 });
+const simulationLimiter = createAsyncRateLimiter({
+  limit: 10,
+  windowMs: 60_000,
+  prefix: "rate:simulate",
+});
 
-function checkSimulationRateLimit(companyId: string): boolean {
-  return simulationLimiter.check(companyId).allowed;
+async function checkSimulationRateLimit(companyId: string): Promise<boolean> {
+  const result = await simulationLimiter.check(companyId);
+  return result.allowed;
 }
 
 // ---------------------------------------------------------------------------
@@ -297,7 +307,7 @@ export async function testAiConnection(
   await requireAdmin();
   await requireCompanyAccess(companyId);
 
-  if (!checkTestConnectionRateLimit(companyId)) {
+  if (!(await checkTestConnectionRateLimit(companyId))) {
     return { ok: false, error: "Limite de testes atingido (máx 5/min). Aguarde um momento." };
   }
 
@@ -522,7 +532,7 @@ export async function simulateAiResponse(
   }
 
   // Rate limit check
-  if (!checkSimulationRateLimit(companyId)) {
+  if (!(await checkSimulationRateLimit(companyId))) {
     return {
       response: "",
       inputTokens: 0,

--- a/erp/src/lib/rate-limiter.ts
+++ b/erp/src/lib/rate-limiter.ts
@@ -1,20 +1,11 @@
-// ─── Rate Limiter Interface + In-Memory Implementation ───────────────────────
+// ─── Rate Limiter Interface + In-Memory & Redis Implementations ─────────────
 // See: https://github.com/diogenesmendes01/MendesAplication/issues/124
+// See: https://github.com/diogenesmendes01/MendesAplication/issues/310
 //
-// ## Current limitation
-// The in-memory implementation is per-process: in a multi-instance deployment
-// (e.g. multiple serverless workers or containers), each process has its own
-// Map, so the effective limit is `limit * N_INSTANCES`.
-//
-// ## Redis migration path
-// 1. Create `RedisRateLimiter` implementing `RateLimiter` interface below
-// 2. Use Redis MULTI/EXEC with sorted sets:
-//    - ZADD key <now> <now>        (add timestamp)
-//    - ZREMRANGEBYSCORE key 0 <now - windowMs>  (prune old)
-//    - ZCARD key                   (count recent)
-//    - EXPIRE key <windowMs/1000>  (auto-cleanup)
-// 3. Swap `createRateLimiter()` to return Redis-backed instance
-// 4. Keep InMemoryRateLimiter as fallback when Redis is unavailable
+// Redis-backed implementation uses INCR + EXPIRE (fixed window, TTL = windowMs).
+// Falls back to InMemoryRateLimiter when Redis is unavailable.
+
+import Redis from "ioredis";
 
 // ─── Interface ────────────────────────────────────────────────────────────────
 
@@ -37,6 +28,15 @@ export interface RateLimiter {
    * Reset rate limit for a specific key. Useful for testing.
    */
   reset(key: string): void;
+}
+
+/**
+ * Async rate limiter interface — used by Redis-backed implementation.
+ * Callers that support Redis should use this interface.
+ */
+export interface AsyncRateLimiter {
+  check(key: string): Promise<RateLimiterResult>;
+  reset(key: string): Promise<void>;
 }
 
 // ─── In-Memory Implementation ─────────────────────────────────────────────────
@@ -87,19 +87,150 @@ export class InMemoryRateLimiter implements RateLimiter {
   }
 }
 
+// ─── Redis Implementation ─────────────────────────────────────────────────────
+
+const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
+
+let redis: Redis | null = null;
+let redisAvailable = true;
+
+function getRedisClient(): Redis | null {
+  if (!redisAvailable) return null;
+
+  if (!redis) {
+    try {
+      redis = new Redis(REDIS_URL, {
+        maxRetriesPerRequest: 1,
+        lazyConnect: true,
+        enableOfflineQueue: false,
+      });
+      redis.on("error", (err) => {
+        console.error("[rate-limiter] Redis error:", err.message);
+        redisAvailable = false;
+      });
+      redis.on("connect", () => {
+        redisAvailable = true;
+      });
+      redis.connect().catch((err) => {
+        console.error("[rate-limiter] Redis connect failed:", err.message);
+        redisAvailable = false;
+      });
+    } catch {
+      redisAvailable = false;
+      return null;
+    }
+  }
+
+  return redisAvailable ? redis : null;
+}
+
+export class RedisRateLimiter implements AsyncRateLimiter {
+  private readonly fallback: InMemoryRateLimiter;
+  private readonly limit: number;
+  private readonly windowMs: number;
+  private readonly prefix: string;
+
+  constructor(opts: { limit: number; windowMs: number; prefix: string }) {
+    this.limit = opts.limit;
+    this.windowMs = opts.windowMs;
+    this.prefix = opts.prefix;
+    this.fallback = new InMemoryRateLimiter({
+      limit: opts.limit,
+      windowMs: opts.windowMs,
+    });
+  }
+
+  async check(key: string): Promise<RateLimiterResult> {
+    const client = getRedisClient();
+    if (!client) {
+      return this.fallback.check(key);
+    }
+
+    const redisKey = `${this.prefix}:${key}`;
+    const windowSec = Math.ceil(this.windowMs / 1000);
+
+    try {
+      const results = await client.multi().incr(redisKey).ttl(redisKey).exec();
+
+      if (!results || results.length < 2) {
+        throw new Error("Redis multi/exec returned unexpected result");
+      }
+
+      const [incrErr, incrVal] = results[0];
+      const [ttlErr, ttlVal] = results[1];
+
+      if (incrErr || ttlErr) {
+        throw new Error("Redis multi/exec contained errors");
+      }
+
+      const count = typeof incrVal === "number" ? incrVal : Number(incrVal);
+      const ttl = typeof ttlVal === "number" ? ttlVal : Number(ttlVal);
+
+      // Set TTL on first increment (ttl === -1 means no expiry set yet)
+      if (ttl === -1) {
+        await client.expire(redisKey, windowSec);
+      }
+
+      if (count > this.limit) {
+        const remainingSec = ttl === -1 ? windowSec : Math.max(ttl, 1);
+        return {
+          allowed: false,
+          remaining: 0,
+          retryAfterMs: remainingSec * 1000,
+        };
+      }
+
+      return {
+        allowed: true,
+        remaining: this.limit - count,
+        retryAfterMs: 0,
+      };
+    } catch (err) {
+      console.error(
+        "[rate-limiter] Redis op failed, falling back to in-memory:",
+        err instanceof Error ? err.message : err,
+      );
+      redisAvailable = false;
+      return this.fallback.check(key);
+    }
+  }
+
+  async reset(key: string): Promise<void> {
+    const client = getRedisClient();
+    if (client) {
+      try {
+        await client.del(`${this.prefix}:${key}`);
+      } catch {
+        // ignore — fallback cleanup below
+      }
+    }
+    this.fallback.reset(key);
+  }
+}
+
 // ─── Factory ──────────────────────────────────────────────────────────────────
 
 /**
- * Creates a rate limiter instance.
- *
- * Currently returns InMemoryRateLimiter.
- * When Redis is available, swap this to return a Redis-backed implementation.
+ * Creates a synchronous in-memory rate limiter.
+ * For Redis-backed rate limiting, use `createAsyncRateLimiter()`.
  */
 export function createRateLimiter(opts: {
   limit: number;
   windowMs: number;
 }): RateLimiter {
-  // TODO(#124): When Redis is available:
-  // if (redisClient) return new RedisRateLimiter(redisClient, opts);
   return new InMemoryRateLimiter(opts);
+}
+
+/**
+ * Creates a Redis-backed rate limiter with automatic in-memory fallback.
+ * Uses INCR + EXPIRE with a fixed window (TTL = windowMs).
+ *
+ * @param opts.prefix - Redis key prefix (e.g. "rate:simulate")
+ */
+export function createAsyncRateLimiter(opts: {
+  limit: number;
+  windowMs: number;
+  prefix: string;
+}): AsyncRateLimiter {
+  return new RedisRateLimiter(opts);
 }


### PR DESCRIPTION
## Mudanças

Substitui os rate limiters in-memory (`simulationRateMap` / `testConnectionRateMap`) por contadores Redis com TTL de 60s.

### O que foi feito

- **`erp/src/lib/rate-limiter.ts`**: Adicionada classe `RedisRateLimiter` que usa `INCR` + `EXPIRE` do Redis (fixed window)
- **`erp/src/app/(app)/configuracoes/ai/actions.ts`**: Trocado `createRateLimiter` por `createAsyncRateLimiter` com prefixos Redis:
  - `rate:testconn:{companyId}` (5 req/min)
  - `rate:simulate:{companyId}` (10 req/min)

### Fallback

Quando Redis não está disponível, cai automaticamente para `InMemoryRateLimiter` (comportamento anterior).

### Backward compatibility

- Interface `RateLimiter` (sync) e `createRateLimiter()` mantidos para outros consumidores
- Testes existentes continuam passando sem alteração

Fixes #310