### PR TITLE
fix(ai-config): improve UX for Testar Conexão button with unsaved changes

### DIFF
--- a/erp/src/app/(app)/configuracoes/ai/components/tab-geral.tsx
+++ b/erp/src/app/(app)/configuracoes/ai/components/tab-geral.tsx
@@ -30,6 +30,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   testAiConnection,
   listAvailableModels,
   getSuggestedModel,
@@ -59,6 +65,8 @@ export function TabGeral({
   >("idle");
   const [connectionError, setConnectionError] = useState("");
   const [suggestion, setSuggestion] = useState<ModelSuggestionData | null>(null);
+
+  const isTestDisabled = testingConnection || hasUnsavedChanges;
 
   // ── Load models when provider changes ─────────────────────────────────────
   const loadModels = useCallback(async () => {
@@ -122,6 +130,27 @@ export function TabGeral({
     }
   }
 
+  // ── Test connection button ────────────────────────────────────────────────
+  const testButtonElement = (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleTestConnection}
+      disabled={isTestDisabled}
+    >
+      {testingConnection ? (
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+      ) : connectionStatus === "success" ? (
+        <CheckCircle2 className="mr-2 h-4 w-4 text-green-600" />
+      ) : connectionStatus === "error" ? (
+        <XCircle className="mr-2 h-4 w-4 text-red-600" />
+      ) : (
+        <Zap className="mr-2 h-4 w-4" />
+      )}
+      Testar Conexão
+    </Button>
+  );
+
   return (
     <div className="space-y-4">
       {/* Provider + API Key */}
@@ -172,32 +201,33 @@ export function TabGeral({
                 placeholder="sk-..."
                 className="flex-1 max-w-md font-mono"
               />
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleTestConnection}
-                disabled={testingConnection || hasUnsavedChanges}
-                title={
-                  hasUnsavedChanges
-                    ? "Salve as configurações antes de testar a conexão"
-                    : undefined
-                }
-              >
-                {testingConnection ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : connectionStatus === "success" ? (
-                  <CheckCircle2 className="mr-2 h-4 w-4 text-green-600" />
-                ) : connectionStatus === "error" ? (
-                  <XCircle className="mr-2 h-4 w-4 text-red-600" />
-                ) : (
-                  <Zap className="mr-2 h-4 w-4" />
-                )}
-                Testar Conexão
-              </Button>
+              {hasUnsavedChanges ? (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      {/* Wrapper span: disabled buttons swallow pointer events, preventing tooltip display */}
+                      <span tabIndex={0} className="inline-flex">
+                        {testButtonElement}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <p>Salve as configurações antes de testar a conexão</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              ) : (
+                testButtonElement
+              )}
             </div>
             {config.apiKey && /^\*{4}/.test(config.apiKey) && (
               <p className="text-sm text-muted-foreground">
                 🔑 Chave configurada. Para alterar, digite uma nova chave.
+              </p>
+            )}
+            {hasUnsavedChanges && (
+              <p className="text-sm text-amber-600">
+                ⚠ Salve as alterações antes de testar a conexão. O teste valida
+                a chave salva no sistema, não a digitada no formulário.
               </p>
             )}
             {connectionStatus === "success" && (


### PR DESCRIPTION
## Problem

`handleTestConnection()` calls `testAiConnection(companyId)` which fetches the API key from the database. If the admin typed a new key but hasn't saved yet, clicking "Testar Conexão" would test the **old** key — misleading UX.

The button was already correctly disabled via `hasUnsavedChanges`, but the feedback was limited to a native HTML `title` attribute tooltip (barely visible).

## Solution

1. **Radix UI Tooltip** — replaced the native `title` with a styled `<Tooltip>` component (consistent with the rest of the UI), with a `<span>` wrapper so the tooltip fires even on the disabled button
2. **Amber warning text** — added a visible `⚠ Salve as alterações antes de testar a conexão. O teste valida a chave salva no sistema, não a digitada no formulário.` message below the API key field when there are unsaved changes
3. **Extracted button element** — avoids JSX duplication between tooltip-wrapped and unwrapped variants

## Changes

- `erp/src/app/(app)/configuracoes/ai/components/tab-geral.tsx`

Fixes #298