### PR TITLE
fix(build): skip postinstall in Docker deps stage — fixes #303

### DIFF
--- a/erp/Dockerfile
+++ b/erp/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine AS deps
 RUN apk add --no-cache libc6-compat openssl
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 # Stage 2: builder
 FROM node:20-alpine AS builder


### PR DESCRIPTION
## Problem

Docker build fails because `npm ci` in the deps stage triggers `postinstall` → `npx prisma generate`, but at that point only `package.json` and `package-lock.json` are copied — no `prisma/schema.prisma` or `prisma.config.ts`.

This causes the generated Prisma client to be empty/broken, resulting in:
```
Module "@prisma/client" has no exported member 'AdditionalContact'
```

## Fix

Use `npm ci --ignore-scripts` in the Dockerfile deps stage. `prisma generate` is already run explicitly in the builder stage where all source files are present.

## Verification

- ✅ `AdditionalContact` model exists in `prisma/schema.prisma`
- ✅ `npx prisma generate` produces correct types
- ✅ `npx tsc --noEmit` passes with zero errors
- ✅ `next build` compiles successfully

Fixes #303