### PR TITLE
fix(ai): reject non-positive dailySpendLimitBrl (frontend + tests)

### DIFF
--- a/erp/src/app/(app)/configuracoes/ai/__tests__/actions.test.ts
+++ b/erp/src/app/(app)/configuracoes/ai/__tests__/actions.test.ts
@@ -462,4 +462,44 @@ describe("updateAiConfig", () => {
     const createPayload = upsertCall.create as Record<string, unknown>;
     expect(createPayload).toHaveProperty("apiKey", null);
   });
+
+  it("throws when dailySpendLimitBrl is negative", async () => {
+    const { updateAiConfig } = await import(
+      "@/app/(app)/configuracoes/ai/actions"
+    );
+
+    await expect(
+      updateAiConfig("company-1", { ...validData, dailySpendLimitBrl: -1 })
+    ).rejects.toThrow(/dailySpendLimitBrl must be a positive number/i);
+  });
+
+  it("throws when dailySpendLimitBrl is zero", async () => {
+    const { updateAiConfig } = await import(
+      "@/app/(app)/configuracoes/ai/actions"
+    );
+
+    await expect(
+      updateAiConfig("company-1", { ...validData, dailySpendLimitBrl: 0 })
+    ).rejects.toThrow(/dailySpendLimitBrl must be a positive number/i);
+  });
+
+  it("accepts null dailySpendLimitBrl (no limit)", async () => {
+    const { updateAiConfig } = await import(
+      "@/app/(app)/configuracoes/ai/actions"
+    );
+
+    await expect(
+      updateAiConfig("company-1", { ...validData, dailySpendLimitBrl: null })
+    ).resolves.not.toThrow();
+  });
+
+  it("accepts positive dailySpendLimitBrl", async () => {
+    const { updateAiConfig } = await import(
+      "@/app/(app)/configuracoes/ai/actions"
+    );
+
+    await expect(
+      updateAiConfig("company-1", { ...validData, dailySpendLimitBrl: 10.5 })
+    ).resolves.not.toThrow();
+  });
 });

--- a/erp/src/app/(app)/configuracoes/ai/components/tab-geral.tsx
+++ b/erp/src/app/(app)/configuracoes/ai/components/tab-geral.tsx
@@ -297,11 +297,16 @@ export function TabGeral({
                   }));
                 }}
                 placeholder="Sem limite"
-                min={0}
+                min={0.01}
                 step={0.5}
-                className="w-32"
+                className={`w-32 ${config.dailySpendLimitBrl !== null && config.dailySpendLimitBrl <= 0 ? "border-red-500 focus-visible:ring-red-500" : ""}`}
               />
             </div>
+            {config.dailySpendLimitBrl !== null && config.dailySpendLimitBrl <= 0 && (
+              <p className="text-xs text-red-500">
+                O limite deve ser um valor positivo (maior que zero).
+              </p>
+            )}
             <p className="text-xs text-muted-foreground">
               Deixe vazio para não limitar. Quando o limite for atingido, o
               agente para de responder automaticamente.

--- a/erp/src/app/(app)/configuracoes/ai/page.tsx
+++ b/erp/src/app/(app)/configuracoes/ai/page.tsx
@@ -65,6 +65,13 @@ export default function AiConfigPage() {
   // ── Save ──────────────────────────────────────────────────────────────────
   async function handleSave() {
     if (!selectedCompanyId) return;
+
+    // Client-side validation: reject non-positive dailySpendLimitBrl
+    if (config.dailySpendLimitBrl !== null && config.dailySpendLimitBrl <= 0) {
+      toast.error("O limite de gasto diário deve ser um valor positivo (maior que zero).");
+      return;
+    }
+
     setSaving(true);
     try {
       await updateAiConfig(selectedCompanyId, config);


### PR DESCRIPTION
## Problema

O campo `dailySpendLimitBrl` aceitava valores negativos no frontend. Se um admin salvasse `-1`, o agente ficava permanentemente bloqueado porque qualquer gasto > -1.

O backend (server action) já rejeitava valores <= 0, mas o frontend não mostrava erro inline — só um toast genérico do server.

## Correções

### Frontend (`tab-geral.tsx`)
- `min={0}` → `min={0.01}` no input HTML
- Borda vermelha + mensagem de erro inline quando valor <= 0

### Page (`page.tsx`)
- Validação client-side em `handleSave()` antes de chamar server action
- Toast de erro específico: "O limite deve ser um valor positivo"

### Testes (`actions.test.ts`)
- ✅ Rejeita `dailySpendLimitBrl: -1` (negativo)
- ✅ Rejeita `dailySpendLimitBrl: 0` (zero)
- ✅ Aceita `dailySpendLimitBrl: null` (sem limite)
- ✅ Aceita `dailySpendLimitBrl: 10.5` (positivo)

**26 testes passando.**

Fixes #297