### PR TITLE
fix: allow apiKey: null in updateAiConfig to support clearing the key

### DIFF
--- a/erp/src/app/(app)/configuracoes/ai/__tests__/actions.test.ts
+++ b/erp/src/app/(app)/configuracoes/ai/__tests__/actions.test.ts
@@ -442,4 +442,24 @@ describe("updateAiConfig", () => {
       updateAiConfig("company-1", { ...validData, apiKey: "short" })
     ).rejects.toThrow(/apiKey too short/i);
   });
+
+  it("clears API key when null is submitted", async () => {
+    const { updateAiConfig } = await import(
+      "@/app/(app)/configuracoes/ai/actions"
+    );
+
+    await updateAiConfig("company-clear-key", { ...validData, apiKey: null });
+
+    // encrypt() must NOT have been called — null means clear the key
+    expect(mockEncrypt).not.toHaveBeenCalled();
+
+    // upsert must set apiKey to null (clearing it)
+    const upsertCall = mockUpsert.mock.calls[0][0] as Record<string, unknown>;
+    const updatePayload = upsertCall.update as Record<string, unknown>;
+    expect(updatePayload).toHaveProperty("apiKey", null);
+    expect(updatePayload).toHaveProperty("apiKeyHint", null);
+
+    const createPayload = upsertCall.create as Record<string, unknown>;
+    expect(createPayload).toHaveProperty("apiKey", null);
+  });
 });

--- a/erp/src/app/(app)/configuracoes/ai/actions.ts
+++ b/erp/src/app/(app)/configuracoes/ai/actions.ts
@@ -23,7 +23,7 @@ export interface AiConfigData {
   maxIterations: number;
   // Provider
   provider: string;
-  apiKey: string; // masked on read, plain on write
+  apiKey: string | null; // masked on read, plain on write, null to clear
   model: string;
   // Channels
   whatsappEnabled: boolean;
@@ -237,11 +237,16 @@ export async function updateAiConfig(
   }
 
   // Determine the apiKey to store:
+  // - If the incoming apiKey is null, clear the key (admin wants to remove it)
   // - If the incoming apiKey is empty or matches the masked pattern, keep existing
   // - Otherwise, validate and encrypt the new value
-  let apiKeyToStore: string | undefined;
-  let apiKeyHintToStore: string | undefined;
-  if (data.apiKey && !MASKED_API_KEY_PATTERN.test(data.apiKey)) {
+  let apiKeyToStore: string | null | undefined;
+  let apiKeyHintToStore: string | null | undefined;
+  if (data.apiKey === null) {
+    // Explicitly clear the API key
+    apiKeyToStore = null;
+    apiKeyHintToStore = null;
+  } else if (data.apiKey && !MASKED_API_KEY_PATTERN.test(data.apiKey)) {
     // Validate minimum key length to surface accidental empty-like submissions
     if (data.apiKey.trim().length < 8) {
       throw new Error("apiKey too short — minimum 8 characters");
@@ -286,7 +291,7 @@ export async function updateAiConfig(
   // Audit log — redact apiKey from the logged data
   const auditData = {
     ...data,
-    apiKey: data.apiKey ? "(redacted)" : "(empty)",
+    apiKey: data.apiKey === null ? "(cleared)" : data.apiKey ? "(redacted)" : "(empty)",
   };
 
   await logAuditEvent({

--- a/erp/src/app/(app)/configuracoes/ai/components/tab-geral.tsx
+++ b/erp/src/app/(app)/configuracoes/ai/components/tab-geral.tsx
@@ -162,7 +162,7 @@ export function TabGeral({
             <div className="flex items-center gap-2">
               <Input
                 type="password"
-                value={config.apiKey}
+                value={config.apiKey ?? ""}
                 onChange={(e) =>
                   setConfig((prev) => ({
                     ...prev,


### PR DESCRIPTION
## Problema

A interface `AiConfigData` define `apiKey` como `string`, impedindo que o admin envie `null` para limpar a chave configurada.

## Solução

- **Interface**: `apiKey: string` → `apiKey: string | null`
- **updateAiConfig**: quando `apiKey === null`, seta `apiKey` e `apiKeyHint` como `null` no banco (sem chamar `encrypt`)
- **Audit log**: distingue `(cleared)` vs `(redacted)` vs `(empty)`
- **Frontend**: `value={config.apiKey ?? ""}` para evitar `null` no input
- **Teste**: cobre o cenário de `apiKey: null`

Fixes #295