### PR TITLE
fix(ai): replace hardcoded BRL/USD rate with dynamic exchange-rate module

### DIFF
--- a/erp/src/lib/ai/__tests__/pricing.test.ts
+++ b/erp/src/lib/ai/__tests__/pricing.test.ts
@@ -4,12 +4,19 @@ import {
   FALLBACK_PRICING,
   BRL_USD_RATE,
   DEFAULT_MODELS,
+  getBrlUsdRateSync,
 } from "@/lib/ai/pricing";
 
 describe("pricing constants", () => {
   it("BRL_USD_RATE is a positive number", () => {
     expect(BRL_USD_RATE).toBeGreaterThan(0);
     expect(typeof BRL_USD_RATE).toBe("number");
+  });
+
+  it("getBrlUsdRateSync returns a positive number", () => {
+    const rate = getBrlUsdRateSync();
+    expect(rate).toBeGreaterThan(0);
+    expect(typeof rate).toBe("number");
   });
 
   it("MODEL_PRICING entries all have positive input and output rates", () => {
@@ -41,7 +48,6 @@ describe("pricing constants", () => {
   });
 
   it("output price is greater than or equal to input price for each model", () => {
-    // Output tokens are typically priced higher than input tokens
     for (const [model, pricing] of Object.entries(MODEL_PRICING)) {
       expect(
         pricing.output,

--- a/erp/src/lib/ai/pricing.ts
+++ b/erp/src/lib/ai/pricing.ts
@@ -5,6 +5,8 @@
 // Review schedule: quarterly (next: 2026-06-16)
 // This file has NO "use server" directive — constants are importable anywhere.
 
+import { getBrlUsdRate, getBrlUsdRateSync } from "@/lib/ai/exchange-rate";
+
 export interface ModelPricing {
   input: number; // USD per 1M input tokens
   output: number; // USD per 1M output tokens
@@ -42,20 +44,22 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
 export const FALLBACK_PRICING: ModelPricing = { input: 1.0, output: 3.0 };
 
 /**
- * BRL/USD exchange rate (synchronous fallback).
+ * BRL/USD exchange rate — dynamic via AwesomeAPI (24h cache).
  *
- * For async consumers (cost-tracker, agent), prefer getBrlUsdRate() from
- * exchange-rate.ts which fetches the real-time rate from AwesomeAPI.
+ * Re-exported from exchange-rate.ts for backward compatibility.
+ * Sync consumers get the cached rate; async consumers should use getBrlUsdRate().
  *
- * This sync constant is kept for backwards compatibility and as fallback
- * when the API is unreachable.
- *
- * Configurable via BRL_USD_RATE env var.
- * See: https://github.com/diogenesmendes01/MendesAplication/issues/125
+ * Fixes: https://github.com/diogenesmendes01/MendesAplication/issues/280
  */
-const _brlUsdRate = parseFloat(process.env.BRL_USD_RATE ?? "5.8");
-export const BRL_USD_RATE =
-  Number.isFinite(_brlUsdRate) && _brlUsdRate > 0 ? _brlUsdRate : 5.8;
+export { getBrlUsdRate, getBrlUsdRateSync };
+
+/**
+ * Synchronous BRL/USD rate accessor for backward compatibility.
+ * Returns the cached dynamic rate (or env fallback on first call).
+ *
+ * @deprecated Use getBrlUsdRate() (async) or getBrlUsdRateSync() instead.
+ */
+export const BRL_USD_RATE: number = getBrlUsdRateSync();
 
 /**
  * Default model names per provider — used as fallback for usage logging


### PR DESCRIPTION
## Summary

Replaces the hardcoded `BRL_USD_RATE` constant in `pricing.ts` with the dynamic rate from `exchange-rate.ts` (AwesomeAPI with 24h cache).

## Changes

- **pricing.ts**: Removed hardcoded `BRL_USD_RATE` (was `5.8`). Now imports and re-exports `getBrlUsdRate()` (async) and `getBrlUsdRateSync()` from `exchange-rate.ts`. Kept `BRL_USD_RATE` as a deprecated re-export of `getBrlUsdRateSync()` for backward compatibility.
- **pricing.test.ts**: Added test for `getBrlUsdRateSync` re-export.

## Backward Compatibility

- `BRL_USD_RATE` still exported (marked `@deprecated`)
- `model-suggester.ts` already uses `getBrlUsdRateSync()` from exchange-rate directly — no change needed
- Test files importing `BRL_USD_RATE` from pricing continue to work

Fixes #280