### PR TITLE
feat(ai): dynamic model discovery with cache + static fallback

### DIFF
--- a/erp/src/app/(app)/configuracoes/ai/actions.ts
+++ b/erp/src/app/(app)/configuracoes/ai/actions.ts
@@ -8,6 +8,7 @@ import { encrypt, decrypt } from "@/lib/encryption";
 import { chatCompletion } from "@/lib/ai/provider";
 import { getTodaySpend, getUsageSummary, type UsageSummary } from "@/lib/ai/cost-tracker";
 import { suggestModel } from "@/lib/ai/model-suggester";
+import { discoverModels } from "@/lib/ai/model-discovery";
 import { runAgentDryRun, type DryRunResult } from "@/lib/ai/agent";
 import type { Prisma } from "@prisma/client";
 
@@ -107,21 +108,6 @@ async function checkSimulationRateLimit(companyId: string): Promise<boolean> {
   const result = await simulationLimiter.check(companyId);
   return result.allowed;
 }
-
-// ---------------------------------------------------------------------------
-// Hardcoded model lists for providers that don't have a list endpoint
-// ---------------------------------------------------------------------------
-
-const HARDCODED_MODELS: Record<string, string[]> = {
-  anthropic: [
-    "claude-opus-4-20250514",
-    "claude-sonnet-4-20250514",
-    "claude-haiku-4-20250414",
-  ],
-  grok: ["grok-2", "grok-2-mini"],
-  qwen: ["qwen-max", "qwen-plus", "qwen-turbo"],
-  deepseek: ["deepseek-chat", "deepseek-reasoner"],
-};
 
 // ---------------------------------------------------------------------------
 // Server Actions
@@ -384,9 +370,6 @@ export async function listAvailableModels(
   await requireAdmin();
   await requireCompanyAccess(companyId);
 
-  // Validate providerOverride against VALID_PROVIDERS (mirrors updateAiConfig).
-  // An unknown provider would silently return [] via HARDCODED_MODELS[provider] ?? [].
-  // Explicit rejection surfaces misconfiguration in the UI immediately.
   if (providerOverride !== undefined && !VALID_PROVIDERS.includes(providerOverride as typeof VALID_PROVIDERS[number])) {
     throw new Error(`provider must be one of: ${VALID_PROVIDERS.join(", ")}`);
   }
@@ -395,58 +378,20 @@ export async function listAvailableModels(
     where: { companyId },
   });
 
-  // Use providerOverride (current UI state) if provided, otherwise fall back to
-  // the persisted config. This ensures the model list reflects the provider
-  // the admin has selected in the form — even before saving.
   const provider = providerOverride ?? config?.provider ?? "openai";
 
-  // For non-OpenAI providers, return hardcoded list
-  if (provider !== "openai") {
-    return HARDCODED_MODELS[provider] ?? [];
-  }
-
-  // For OpenAI: try to fetch from API
-  if (!config?.apiKey) {
-    return ["gpt-4o", "gpt-4o-mini"];
-  }
-
-  let apiKey: string;
-  try {
-    apiKey = decrypt(config.apiKey);
-  } catch {
-    return ["gpt-4o", "gpt-4o-mini"];
-  }
-
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 10000);
-
-    const res = await fetch("https://api.openai.com/v1/models", {
-      headers: { Authorization: `Bearer ${apiKey}` },
-      signal: controller.signal,
-    });
-    clearTimeout(timer);
-
-    if (!res.ok) {
-      return ["gpt-4o", "gpt-4o-mini"];
+  // Decrypt API key if available (needed for dynamic discovery)
+  let apiKey: string | undefined;
+  if (config?.apiKey) {
+    try {
+      apiKey = decrypt(config.apiKey);
+    } catch {
+      // Fall through — discoverModels will use static fallback
     }
-
-    const data = await res.json();
-    const models: string[] = (data.data ?? [])
-      .map((m: { id: string }) => m.id)
-      .filter(
-        (id: string) =>
-          id.startsWith("gpt-") &&
-          !id.includes("instruct") &&
-          !id.includes("realtime") &&
-          !id.includes("audio"),
-      )
-      .sort();
-
-    return models.length > 0 ? models : ["gpt-4o", "gpt-4o-mini"];
-  } catch {
-    return ["gpt-4o", "gpt-4o-mini"];
   }
+
+  // Dynamic discovery with cache + static fallback (all providers)
+  return discoverModels(provider, { apiKey });
 }
 
 /**

--- a/erp/src/lib/ai/__tests__/model-discovery.test.ts
+++ b/erp/src/lib/ai/__tests__/model-discovery.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  discoverModels,
+  getModelsSync,
+  clearModelCache,
+  STATIC_MODELS,
+} from "@/lib/ai/model-discovery";
+
+beforeEach(() => {
+  clearModelCache();
+});
+
+describe("STATIC_MODELS", () => {
+  it("has entries for all known providers", () => {
+    expect(STATIC_MODELS.openai).toBeDefined();
+    expect(STATIC_MODELS.anthropic).toBeDefined();
+    expect(STATIC_MODELS.grok).toBeDefined();
+    expect(STATIC_MODELS.qwen).toBeDefined();
+    expect(STATIC_MODELS.deepseek).toBeDefined();
+  });
+
+  it("each provider has at least one model", () => {
+    for (const [provider, models] of Object.entries(STATIC_MODELS)) {
+      expect(models.length, `${provider} should have models`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("getModelsSync", () => {
+  it("returns static models when cache is empty", () => {
+    const models = getModelsSync("openai");
+    expect(models).toEqual(STATIC_MODELS.openai);
+  });
+
+  it("returns empty array for unknown provider", () => {
+    const models = getModelsSync("unknown-provider");
+    expect(models).toEqual([]);
+  });
+});
+
+describe("discoverModels", () => {
+  it("returns static models when no API key provided", async () => {
+    const models = await discoverModels("anthropic");
+    expect(models).toEqual(STATIC_MODELS.anthropic);
+  });
+
+  it("returns static models for providers without list endpoint", async () => {
+    // anthropic and qwen have no list endpoint → always returns static
+    const models = await discoverModels("qwen", { apiKey: "fake-key" });
+    expect(models).toEqual(STATIC_MODELS.qwen);
+  });
+
+  it("returns empty array for unknown provider", async () => {
+    const models = await discoverModels("unknown");
+    expect(models).toEqual([]);
+  });
+
+  it("falls back to static when API key is missing for openai", async () => {
+    const models = await discoverModels("openai");
+    expect(models).toEqual(STATIC_MODELS.openai);
+  });
+});

--- a/erp/src/lib/ai/model-discovery.ts
+++ b/erp/src/lib/ai/model-discovery.ts
@@ -1,0 +1,172 @@
+import { logger } from "@/lib/logger";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface DiscoveryOptions {
+  apiKey?: string;
+  cacheTtlMs?: number;
+}
+
+interface CacheEntry {
+  models: string[];
+  fetchedAt: number;
+}
+
+// ─── Static fallback lists ────────────────────────────────────────────────────
+// Used when dynamic discovery is unavailable (no API key, network error, etc.)
+
+export const STATIC_MODELS: Record<string, string[]> = {
+  openai: ["gpt-4o", "gpt-4o-mini"],
+  anthropic: [
+    "claude-opus-4-20250514",
+    "claude-sonnet-4-20250514",
+    "claude-haiku-4-20250414",
+  ],
+  grok: ["grok-2", "grok-2-mini"],
+  qwen: ["qwen-max", "qwen-plus", "qwen-turbo"],
+  deepseek: ["deepseek-reasoner", "deepseek-chat"],
+};
+
+// ─── Provider API endpoints ───────────────────────────────────────────────────
+
+const PROVIDER_ENDPOINTS: Record<string, string> = {
+  openai: "https://api.openai.com/v1/models",
+  deepseek: "https://api.deepseek.com/models",
+  grok: "https://api.x.ai/v1/models",
+};
+
+// ─── Model ID filters per provider ───────────────────────────────────────────
+// Only return chat-capable models, not embeddings, TTS, image, etc.
+
+const MODEL_FILTERS: Record<string, (id: string) => boolean> = {
+  openai: (id) =>
+    id.startsWith("gpt-") &&
+    !id.includes("instruct") &&
+    !id.includes("realtime") &&
+    !id.includes("audio") &&
+    !id.includes("search"),
+  deepseek: (id) =>
+    id.startsWith("deepseek-") &&
+    !id.includes("embed"),
+  grok: (id) =>
+    id.startsWith("grok-") &&
+    !id.includes("embed"),
+};
+
+// ─── In-memory cache ──────────────────────────────────────────────────────────
+
+const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Clear the model discovery cache. Useful for testing or forced refresh.
+ */
+export function clearModelCache(): void {
+  cache.clear();
+}
+
+/**
+ * Clear cache for a specific provider.
+ */
+export function clearProviderCache(provider: string): void {
+  cache.delete(provider);
+}
+
+// ─── Discovery logic ──────────────────────────────────────────────────────────
+
+/**
+ * Fetch models from a provider's /models API endpoint.
+ * Returns null on any failure (network, auth, parse error).
+ */
+async function fetchModelsFromApi(
+  provider: string,
+  apiKey: string,
+): Promise<string[] | null> {
+  const endpoint = PROVIDER_ENDPOINTS[provider];
+  if (!endpoint) return null;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 10_000);
+
+    const res = await fetch(endpoint, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+
+    if (!res.ok) {
+      logger.warn(
+        `[model-discovery] ${provider} API returned ${res.status}`,
+      );
+      return null;
+    }
+
+    const data = await res.json();
+    const allModels: string[] = (data.data ?? []).map(
+      (m: { id: string }) => m.id,
+    );
+
+    const filter = MODEL_FILTERS[provider];
+    const filtered = filter ? allModels.filter(filter) : allModels;
+
+    return filtered.length > 0 ? filtered.sort() : null;
+  } catch (err) {
+    logger.warn(
+      `[model-discovery] Failed to fetch models from ${provider}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Discover available models for a provider.
+ *
+ * Strategy:
+ * 1. Return from cache if fresh
+ * 2. If provider has a list endpoint AND apiKey is provided, fetch dynamically
+ * 3. Cache the result on success
+ * 4. Fall back to STATIC_MODELS on failure or when no endpoint/key available
+ *
+ * This function is safe to call without an API key — it will simply return
+ * the static fallback list.
+ */
+export async function discoverModels(
+  provider: string,
+  options: DiscoveryOptions = {},
+): Promise<string[]> {
+  const { apiKey, cacheTtlMs = DEFAULT_CACHE_TTL_MS } = options;
+
+  // 1. Check cache
+  const cached = cache.get(provider);
+  if (cached && Date.now() - cached.fetchedAt < cacheTtlMs) {
+    return cached.models;
+  }
+
+  // 2. Try dynamic discovery if possible
+  if (apiKey && PROVIDER_ENDPOINTS[provider]) {
+    const models = await fetchModelsFromApi(provider, apiKey);
+    if (models) {
+      cache.set(provider, { models, fetchedAt: Date.now() });
+      return models;
+    }
+  }
+
+  // 3. Fallback to static list
+  return STATIC_MODELS[provider] ?? [];
+}
+
+/**
+ * Synchronous version that only returns cached or static models.
+ * Used by suggestModel() which must remain a pure sync function.
+ */
+export function getModelsSync(provider: string): string[] {
+  const cached = cache.get(provider);
+  if (cached && Date.now() - cached.fetchedAt < DEFAULT_CACHE_TTL_MS) {
+    return cached.models;
+  }
+  return STATIC_MODELS[provider] ?? [];
+}

--- a/erp/src/lib/ai/model-suggester.ts
+++ b/erp/src/lib/ai/model-suggester.ts
@@ -1,5 +1,6 @@
 import { MODEL_PRICING } from "@/lib/ai/pricing";
 import { getBrlUsdRateSync } from "@/lib/ai/exchange-rate";
+import { getModelsSync, STATIC_MODELS } from "@/lib/ai/model-discovery";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -16,22 +17,6 @@ interface ModelSuggestion {
  */
 const ESTIMATED_DAILY_INPUT_TOKENS = 100_000;
 const ESTIMATED_DAILY_OUTPUT_TOKENS = 100_000;
-
-/**
- * Models available per provider, ordered from most powerful to least powerful.
- * suggestModel() picks the first (most capable) model that fits the budget.
- */
-const PROVIDER_MODELS: Record<string, string[]> = {
-  openai: ["gpt-4o", "gpt-4o-mini"],
-  anthropic: [
-    "claude-opus-4-20250514",
-    "claude-sonnet-4-20250514",
-    "claude-haiku-4-20250414",
-  ],
-  grok: ["grok-2", "grok-2-mini"],
-  qwen: ["qwen-max", "qwen-plus", "qwen-turbo"],
-  deepseek: ["deepseek-reasoner", "deepseek-chat"],
-};
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -53,15 +38,35 @@ function estimateDailyCostBrl(model: string): number {
  * Returns the most powerful model for a given provider that fits
  * within the daily budget (BRL).
  *
+ * Uses dynamically discovered models (from cache) when available,
+ * falling back to the static list. For cost-based ranking, only models
+ * present in MODEL_PRICING are considered.
+ *
  * Pure function — no I/O, no DB access, no "use server" needed.
  */
 export function suggestModel(
   provider: string,
   dailyBudgetBrl: number
 ): ModelSuggestion {
-  const models = PROVIDER_MODELS[provider];
+  // getModelsSync returns cached dynamic models or static fallback
+  const discoveredModels = getModelsSync(provider);
 
-  if (!models || models.length === 0) {
+  // For suggestion purposes, we need models with known pricing.
+  // Use the static list order (most powerful → least powerful) as the
+  // ranked subset, since dynamically discovered models may include
+  // models without pricing info.
+  const rankedModels = STATIC_MODELS[provider] ?? [];
+
+  // Merge: use ranked static list but also include any discovered models
+  // that have pricing info (preserving static order first)
+  const models = [
+    ...rankedModels,
+    ...discoveredModels.filter(
+      (m) => !rankedModels.includes(m) && MODEL_PRICING[m],
+    ),
+  ];
+
+  if (models.length === 0) {
     return { model: "gpt-4o-mini", estimatedDailyCostBrl: estimateDailyCostBrl("gpt-4o-mini") };
   }
 


### PR DESCRIPTION
## Summary

Replace hardcoded `PROVIDER_MODELS` and `HARDCODED_MODELS` with a centralized `model-discovery` module that fetches models dynamically from provider APIs.

## Changes

### New: `erp/src/lib/ai/model-discovery.ts`
- Centralized model discovery service
- Dynamic fetch from provider APIs (OpenAI, DeepSeek, Grok) when API key available
- In-memory cache with 1-hour TTL
- Static fallback lists for all providers (Anthropic, Qwen use static-only)
- `discoverModels()` — async, with API fetch + cache
- `getModelsSync()` — sync, cache-or-static (for `suggestModel`)
- `clearModelCache()` / `clearProviderCache()` — for testing/refresh

### Updated: `model-suggester.ts`
- Removed hardcoded `PROVIDER_MODELS` constant
- Now imports from `model-discovery` module
- Uses `getModelsSync()` for ranked model lists
- Merges dynamically discovered models that have pricing info

### Updated: `actions.ts`
- Removed `HARDCODED_MODELS` constant
- `listAvailableModels()` now uses `discoverModels()` for **all** providers (not just OpenAI)
- Simplified from ~60 lines to ~25 lines

### New: `model-discovery.test.ts`
- Tests for static models, sync access, and async discovery fallbacks

## How it works

```
listAvailableModels(companyId, provider)
  → discoverModels(provider, { apiKey })
    → cache hit? return cached
    → API endpoint exists + key? fetch → cache → return
    → fallback to STATIC_MODELS[provider]
```

When a provider launches a new model, it appears automatically via the API — no PR needed.

Fixes #287