### PR TITLE
fix: warn and optionally block global AI env fallback

### DIFF
--- a/erp/.env.example
+++ b/erp/.env.example
@@ -21,6 +21,10 @@ AI_API_KEY="your-ai-api-key"
 AI_MODEL=""
 AI_TIMEOUT="30000"
 
+# Block AI calls when company has no API key configured (prevents unattributed costs)
+# Set to "true" to hard-block global env fallback
+BLOCK_GLOBAL_AI_FALLBACK="false"
+
 # AI Agent - Embeddings
 AI_EMBEDDING_PROVIDER="openai"
 AI_EMBEDDING_KEY="your-embedding-api-key"

--- a/erp/src/lib/ai/agent.ts
+++ b/erp/src/lib/ai/agent.ts
@@ -331,8 +331,7 @@ export async function runAgent(
       temperature: aiConfig.temperature,
     };
   } else {
-    log.warn("No apiKey for company, falling back to global env — usage costs unattributed");
-    providerConfig = await getEnvProviderConfig();
+    providerConfig = await getEnvProviderConfig({ companyId, ticketId });
   }
 
   // Load ticket with client and contact info
@@ -540,8 +539,7 @@ export async function runAgentDryRun(
       temperature: aiConfig.temperature,
     };
   } else {
-    log.warn("No apiKey for company, falling back to global env — usage costs unattributed");
-    providerConfig = await getEnvProviderConfig();
+    providerConfig = await getEnvProviderConfig({ companyId, ticketId: "simulation" });
   }
 
   const maxIterations = aiConfig.maxIterations || 5;

--- a/erp/src/lib/ai/embeddings.ts
+++ b/erp/src/lib/ai/embeddings.ts
@@ -1,8 +1,9 @@
 
-
 "use server";
 
 import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+import { isGlobalFallbackBlocked } from "./provider";
 import { chunkText, cosineSimilarity } from "@/lib/ai/embedding-utils";
 export { chunkText, cosineSimilarity };
 
@@ -29,15 +30,31 @@ const DEFAULT_EMBEDDING_MODELS: Record<string, string> = {
  * Generates an embedding vector for the given text using the configured
  * embedding provider (AI_EMBEDDING_PROVIDER env).
  * Supports OpenAI-compatible APIs (openai, deepseek).
+ *
+ * ⚠️  Uses global env vars for API key — costs are NOT attributed per-company.
+ *     When BLOCK_GLOBAL_AI_FALLBACK=true, this will throw unless a key is
+ *     explicitly provided.
  */
 export async function generateEmbedding(text: string): Promise<number[]> {
   const provider = process.env.AI_EMBEDDING_PROVIDER || "openai";
   const apiKey = process.env.AI_EMBEDDING_KEY;
+
   if (!apiKey) {
+    if (isGlobalFallbackBlocked()) {
+      throw new Error(
+        "AI_EMBEDDING_KEY not set and global fallback is blocked (BLOCK_GLOBAL_AI_FALLBACK=true). " +
+          "Configure AI_EMBEDDING_KEY or a per-company embedding key.",
+      );
+    }
     throw new Error(
       `AI_EMBEDDING_KEY nao configurada para provider ${provider}`
     );
   }
+
+  // Warn that embedding calls use global keys (unattributed costs)
+  logger.warn(
+    "Embedding call using global env key (AI_EMBEDDING_KEY) — costs are not attributed per-company",
+  );
 
   const model =
     process.env.AI_EMBEDDING_MODEL || DEFAULT_EMBEDDING_MODELS[provider] || "text-embedding-3-small";

--- a/erp/src/lib/ai/provider.ts
+++ b/erp/src/lib/ai/provider.ts
@@ -1,8 +1,8 @@
 
-
 "use server";
 
 import { DEFAULT_MODELS } from "./pricing";
+import { logger } from "@/lib/logger";
 
 // ─── Interfaces ───────────────────────────────────────────────────────────────
 
@@ -51,13 +51,51 @@ const PROVIDER_BASE_URLS: Record<string, string> = {
   qwen: "https://dashscope.aliyuncs.com/compatible-mode",
 };
 
+// ─── Global fallback guard ────────────────────────────────────────────────────
+
+/**
+ * Returns true when the BLOCK_GLOBAL_AI_FALLBACK env var is set to a truthy
+ * value ("true", "1", "yes").  When enabled, AI calls that would fall back to
+ * the global env API key are blocked instead, preventing unattributed costs.
+ */
+export function isGlobalFallbackBlocked(): boolean {
+  const raw = (process.env.BLOCK_GLOBAL_AI_FALLBACK || "").toLowerCase().trim();
+  return ["true", "1", "yes"].includes(raw);
+}
+
 // ─── Backward-compat helper ───────────────────────────────────────────────────
 
 /**
  * Reads provider config from legacy environment variables.
  * Use when caller does not have per-company config available.
+ *
+ * @param context  Optional context for structured logging (companyId, ticketId, etc.)
+ *
+ * ⚠️  Emits a warning log when used — costs from this path are NOT attributed
+ *     to any company.  Set BLOCK_GLOBAL_AI_FALLBACK=true to hard-block instead.
  */
-export async function getEnvProviderConfig(): Promise<ProviderConfig> {
+export async function getEnvProviderConfig(
+  context?: { companyId?: string; ticketId?: string },
+): Promise<ProviderConfig> {
+  // ── Guard: optionally block global fallback entirely ────────────────────
+  if (isGlobalFallbackBlocked()) {
+    const msg =
+      "Global AI env fallback is blocked (BLOCK_GLOBAL_AI_FALLBACK=true). " +
+      "Configure an API key for this company in AI settings.";
+    logger.error(
+      { companyId: context?.companyId, ticketId: context?.ticketId },
+      msg,
+    );
+    throw new Error(msg);
+  }
+
+  // ── Warn: fallback causes unattributed costs ───────────────────────────
+  logger.warn(
+    { companyId: context?.companyId, ticketId: context?.ticketId },
+    "AI call using global env fallback — costs will NOT be attributed to a company. " +
+      "Configure a per-company API key or set BLOCK_GLOBAL_AI_FALLBACK=true to prevent this.",
+  );
+
   const provider = process.env.AI_PROVIDER || "openai";
   const apiKey = process.env.AI_API_KEY;
   if (!apiKey) {


### PR DESCRIPTION
## Issue
Fixes #286 — Global env fallback causes unattributed AI costs

## Changes

### `erp/src/lib/ai/provider.ts`
- Added `isGlobalFallbackBlocked()` — reads `BLOCK_GLOBAL_AI_FALLBACK` env var
- `getEnvProviderConfig()` now accepts optional `{ companyId, ticketId }` context
- Emits structured `logger.warn` with company/ticket context when fallback is used
- When `BLOCK_GLOBAL_AI_FALLBACK=true`, throws with `logger.error` instead of proceeding

### `erp/src/lib/ai/agent.ts`
- Both `runAgent` and `runAgentDryRun` now pass context to `getEnvProviderConfig()`
- Removed redundant `log.warn` calls (now handled centrally in provider.ts)

### `erp/src/lib/ai/embeddings.ts`
- Added warning log when global `AI_EMBEDDING_KEY` is used
- Respects `BLOCK_GLOBAL_AI_FALLBACK` flag for embeddings too

### `erp/.env.example`
- Documented `BLOCK_GLOBAL_AI_FALLBACK` flag (default: `false`)

## Behavior
| `BLOCK_GLOBAL_AI_FALLBACK` | Company has API key | Result |
|---|---|---|
| `false` (default) | ❌ | ⚠️ Warning log + proceeds with global key |
| `true` | ❌ | ❌ Error thrown, AI call blocked |
| any | ✅ | ✅ Uses company key (no change) |