### PR TITLE
fix: remove obsolete TODO(#103) comment in tool-executor.ts

### DIFF
--- a/erp/src/lib/ai/tool-executor.ts
+++ b/erp/src/lib/ai/tool-executor.ts
@@ -250,9 +250,6 @@ async function executeRespond(
 // content could cause the LLM to emit malicious HTML (tracking pixels,
 // phishing links, arbitrary scripts) in outgoing replies.
 //
-// TODO(#103): Replace with `sanitize-html` package for production-grade
-// sanitization once the dependency is approved and added.
-//
 // ─── RESPOND_EMAIL ───────────────────────────────────────────────────────────
 
 async function executeRespondEmail(


### PR DESCRIPTION
## What
Remove obsolete `TODO(#103)` comment from `tool-executor.ts`.

## Why
Issue #103 has already been resolved — `sanitize-utils.ts` confirms the `sanitize-html` package is in use.

Fixes #237