### PR TITLE
refactor(ai): extract useAiConfig and useAiUsage hooks (#244)

### DIFF
--- a/erp/src/app/(app)/configuracoes/ai/components/tab-consumo.tsx
+++ b/erp/src/app/(app)/configuracoes/ai/components/tab-consumo.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useState } from "react";
-import { toast } from "sonner";
 import { BarChart3, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -12,11 +10,8 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
-import {
-  getAiUsageSummary,
-  getTodaySpendAction,
-} from "../actions";
-import type { AiConfigData, UsageSummary } from "./types";
+import { useAiUsage } from "../hooks";
+import type { AiConfigData } from "./types";
 
 interface TabConsumoProps {
   companyId: string;
@@ -24,28 +19,8 @@ interface TabConsumoProps {
 }
 
 export function TabConsumo({ companyId, config }: TabConsumoProps) {
-  const [usageSummary, setUsageSummary] = useState<UsageSummary | null>(null);
-  const [todaySpend, setTodaySpend] = useState<number>(0);
-  const [loadingUsage, setLoadingUsage] = useState(false);
-
-  async function loadUsageData() {
-    if (!companyId) return;
-    setLoadingUsage(true);
-    try {
-      const [summary, spend] = await Promise.all([
-        getAiUsageSummary(companyId, 30),
-        getTodaySpendAction(companyId),
-      ]);
-      setUsageSummary(summary);
-      setTodaySpend(spend);
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Erro ao carregar consumo",
-      );
-    } finally {
-      setLoadingUsage(false);
-    }
-  }
+  const { usageSummary, todaySpend, loadingUsage, loadUsageData } =
+    useAiUsage(companyId);
 
   return (
     <div className="space-y-4">

--- a/erp/src/app/(app)/configuracoes/ai/hooks/index.ts
+++ b/erp/src/app/(app)/configuracoes/ai/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useAiConfig } from "./useAiConfig";
+export { useAiUsage } from "./useAiUsage";

--- a/erp/src/app/(app)/configuracoes/ai/hooks/useAiConfig.ts
+++ b/erp/src/app/(app)/configuracoes/ai/hooks/useAiConfig.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { toast } from "sonner";
+import { getAiConfig, updateAiConfig } from "../actions";
+import { DEFAULT_CONFIG, type AiConfigData } from "../components/types";
+
+export function useAiConfig(companyId: string | null) {
+  const [config, setConfig] = useState<AiConfigData>(DEFAULT_CONFIG);
+  const [savedConfig, setSavedConfig] = useState<AiConfigData>(DEFAULT_CONFIG);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const hasUnsavedChanges =
+    !loading && JSON.stringify(config) !== JSON.stringify(savedConfig);
+
+  const loadData = useCallback(async () => {
+    if (!companyId) return;
+    setLoading(true);
+    try {
+      const data = await getAiConfig(companyId);
+      setConfig(data);
+      setSavedConfig(data);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Erro ao carregar configurações",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [companyId]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleSave = useCallback(async () => {
+    if (!companyId) return;
+
+    if (config.dailySpendLimitBrl !== null && config.dailySpendLimitBrl <= 0) {
+      toast.error("O limite de gasto diário deve ser um valor positivo (maior que zero).");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await updateAiConfig(companyId, config);
+      setSavedConfig(config);
+      toast.success("Configurações do Agente IA salvas com sucesso");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Erro ao salvar");
+    } finally {
+      setSaving(false);
+    }
+  }, [companyId, config]);
+
+  return {
+    config,
+    setConfig,
+    loading,
+    saving,
+    hasUnsavedChanges,
+    handleSave,
+  };
+}

--- a/erp/src/app/(app)/configuracoes/ai/hooks/useAiUsage.ts
+++ b/erp/src/app/(app)/configuracoes/ai/hooks/useAiUsage.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { toast } from "sonner";
+import { getAiUsageSummary, getTodaySpendAction } from "../actions";
+import type { UsageSummary } from "../components/types";
+
+export function useAiUsage(companyId: string | null) {
+  const [usageSummary, setUsageSummary] = useState<UsageSummary | null>(null);
+  const [todaySpend, setTodaySpend] = useState<number>(0);
+  const [loadingUsage, setLoadingUsage] = useState(false);
+
+  const loadUsageData = useCallback(async () => {
+    if (!companyId) return;
+    setLoadingUsage(true);
+    try {
+      const [summary, spend] = await Promise.all([
+        getAiUsageSummary(companyId, 30),
+        getTodaySpendAction(companyId),
+      ]);
+      setUsageSummary(summary);
+      setTodaySpend(spend);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Erro ao carregar consumo",
+      );
+    } finally {
+      setLoadingUsage(false);
+    }
+  }, [companyId]);
+
+  return {
+    usageSummary,
+    todaySpend,
+    loadingUsage,
+    loadUsageData,
+  };
+}

--- a/erp/src/app/(app)/configuracoes/ai/page.tsx
+++ b/erp/src/app/(app)/configuracoes/ai/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { toast } from "sonner";
 import {
   Save,
   Zap,
@@ -16,16 +14,14 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useCompany } from "@/contexts/company-context";
-import { getAiConfig, updateAiConfig } from "./actions";
 import {
   TabGeral,
   TabWhatsApp,
   TabEmail,
   TabConsumo,
   TabSimulador,
-  DEFAULT_CONFIG,
-  type AiConfigData,
 } from "./components";
+import { useAiConfig } from "./hooks";
 
 // ---------------------------------------------------------------------------
 // Page
@@ -33,58 +29,16 @@ import {
 
 export default function AiConfigPage() {
   const { selectedCompanyId } = useCompany();
-  const [config, setConfig] = useState<AiConfigData>(DEFAULT_CONFIG);
-  const [savedConfig, setSavedConfig] = useState<AiConfigData>(DEFAULT_CONFIG);
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
+  const {
+    config,
+    setConfig,
+    loading,
+    saving,
+    hasUnsavedChanges,
+    handleSave,
+  } = useAiConfig(selectedCompanyId);
 
-  const hasUnsavedChanges =
-    !loading && JSON.stringify(config) !== JSON.stringify(savedConfig);
-
-  // ── Load config ───────────────────────────────────────────────────────────
-  const loadData = useCallback(async () => {
-    if (!selectedCompanyId) return;
-    setLoading(true);
-    try {
-      const data = await getAiConfig(selectedCompanyId);
-      setConfig(data);
-      setSavedConfig(data);
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Erro ao carregar configurações",
-      );
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedCompanyId]);
-
-  useEffect(() => {
-    loadData();
-  }, [loadData]);
-
-  // ── Save ──────────────────────────────────────────────────────────────────
-  async function handleSave() {
-    if (!selectedCompanyId) return;
-
-    // Client-side validation: reject non-positive dailySpendLimitBrl
-    if (config.dailySpendLimitBrl !== null && config.dailySpendLimitBrl <= 0) {
-      toast.error("O limite de gasto diário deve ser um valor positivo (maior que zero).");
-      return;
-    }
-
-    setSaving(true);
-    try {
-      await updateAiConfig(selectedCompanyId, config);
-      setSavedConfig(config);
-      toast.success("Configurações do Agente IA salvas com sucesso");
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Erro ao salvar");
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  // ── Guards ────────────────────────────────────────────────────────────────
+  // ── Guards ────────────────────────────────────────────────────────────────────────
   if (!selectedCompanyId) {
     return (
       <div className="flex h-64 items-center justify-center text-muted-foreground">
@@ -102,7 +56,7 @@ export default function AiConfigPage() {
     );
   }
 
-  // ── Render ────────────────────────────────────────────────────────────────
+  // ── Render ────────────────────────────────────────────────────────────────────────
   return (
     <div className="space-y-6">
       {/* Header */}


### PR DESCRIPTION
## Summary

Extracts `useAiConfig` and `useAiUsage` hooks into separate files, completing the God Component decomposition from issue #149.

### Changes

- **`hooks/useAiConfig.ts`** — manages AI config state: load, save, dirty tracking
- **`hooks/useAiUsage.ts`** — manages usage/consumption state: summary, today spend, loading
- **`hooks/index.ts`** — barrel export
- **`page.tsx`** — simplified to use `useAiConfig` hook (removed ~40 lines of inline state)
- **`tab-consumo.tsx`** — simplified to use `useAiUsage` hook (removed inline state + action imports)

### Behavior

No functional changes. All state logic preserved exactly as-is, just moved to dedicated hook files.

Fixes #244