### PR TITLE
fix: add optional chaining to ticket.client in AI agent flow

### DIFF
--- a/erp/src/lib/ai/agent.ts
+++ b/erp/src/lib/ai/agent.ts
@@ -393,7 +393,7 @@ export async function runAgent(
     return { responded: false, escalated: false, iterations: 0, error: "Ticket not found" };
   }
 
-  const contactPhone = ticket.contact?.whatsapp || ticket.client.telefone;
+  const contactPhone = ticket.contact?.whatsapp || ticket.client?.telefone;
   if (channel === "WHATSAPP" && !contactPhone) {
     return {
       responded: false,
@@ -438,7 +438,7 @@ export async function runAgent(
       ? aiConfig.emailPersona
       : aiConfig.persona;
 
-  const clientName = ticket.contact?.name || ticket.client.name;
+  const clientName = ticket.contact?.name || ticket.client?.name;
   const systemPrompt =
     channel === "EMAIL"
       ? buildEmailSystemPrompt(persona, clientName, historyContext, aiConfig.emailSignature)


### PR DESCRIPTION
## Problema

`ticket.client.telefone` e `ticket.client.name` em `agent.ts` (função `runAgent`) eram acessados sem optional chaining. Se `client` for `null`/`undefined`, causa runtime crash.

## Correção

- `ticket.client.telefone` → `ticket.client?.telefone`
- `ticket.client.name` → `ticket.client?.name`

Fixes #118