### PR TITLE
fix(ai): add null-check and stale-cleanup to suggestion useEffect (#143)

### DIFF
--- a/erp/src/app/(app)/configuracoes/ai/components/tab-geral.tsx
+++ b/erp/src/app/(app)/configuracoes/ai/components/tab-geral.tsx
@@ -89,14 +89,18 @@ export function TabGeral({
   }, [loading, companyId, config.provider, loadModels]);
 
   // ── Load suggestion when budget or provider changes ───────────────────────
+  // Fix #143: companyId (selectedCompanyId) in deps + null-check + stale cleanup
   useEffect(() => {
-    if (companyId && config.dailySpendLimitBrl && config.dailySpendLimitBrl > 0) {
-      getSuggestedModel(companyId, config.provider, config.dailySpendLimitBrl).then(
-        setSuggestion,
-      );
-    } else {
+    if (!companyId || !config.dailySpendLimitBrl || config.dailySpendLimitBrl <= 0) {
       setSuggestion(null);
+      return;
     }
+
+    let cancelled = false;
+    getSuggestedModel(companyId, config.provider, config.dailySpendLimitBrl).then(
+      (result) => { if (!cancelled) setSuggestion(result); },
+    );
+    return () => { cancelled = true; };
   }, [companyId, config.provider, config.dailySpendLimitBrl]);
 
   function handleProviderChange(provider: string) {


### PR DESCRIPTION
## What

Fixes #143 — useEffect com dependency faltando em page.tsx (selectedCompanyId) + null-check omitido.

## Context

The original problematic `useEffect` in `page.tsx:173-181` (reported during PR #71 review) was moved to `tab-geral.tsx` during the component extraction refactor (`4d22e36`). The dependency array (`companyId`) and null-check were implicitly fixed during that refactor.

## Changes

**`erp/src/app/(app)/configuracoes/ai/components/tab-geral.tsx`**
- Refactored the suggestion `useEffect` with explicit early-return guard for `!companyId`
- Added `cancelled` flag cleanup to prevent stale promise state updates (React best practice)
- `companyId` (mapped from `selectedCompanyId`) remains in the dependency array ✅
- Null-check present before calling `getSuggestedModel` ✅

## Acceptance Criteria
- [x] Null-check adicionado antes de chamar `getSuggestedModel`
- [x] `selectedCompanyId` incluído no array de dependências (as `companyId` prop)
- [x] Build passa sem erros TypeScript
- [x] ESLint sem warnings no arquivo

Fixes diogenesmendes01/MendesAplication#143