### PR TITLE
fix(ai): strong typing for tool definitions with compile-time required param inference

### DIFF
--- a/erp/src/lib/ai/provider.ts
+++ b/erp/src/lib/ai/provider.ts
@@ -22,11 +22,72 @@ export interface AiMessage {
   tool_call_id?: string;
 }
 
-export interface AiToolDefinition {
-  name: string;
-  description: string;
-  parameters: Record<string, unknown>; // JSON Schema object
+// ─── Strongly-typed tool definitions ──────────────────────────────────────────
+
+/** JSON-Schema property descriptor used inside tool parameter schemas. */
+export interface JsonSchemaProperty {
+  type: "string" | "number" | "boolean" | "array" | "object";
+  description?: string;
+  enum?: string[];
+  items?: JsonSchemaProperty;
 }
+
+export interface AiToolParameters<
+  Props extends Record<string, JsonSchemaProperty> = Record<string, JsonSchemaProperty>,
+  Req extends readonly (keyof Props & string)[] = readonly (keyof Props & string)[],
+> {
+  type: "object";
+  properties: Props;
+  required: Req;
+}
+
+export interface AiToolDefinition<
+  N extends string = string,
+  Props extends Record<string, JsonSchemaProperty> = Record<string, JsonSchemaProperty>,
+  Req extends readonly (keyof Props & string)[] = readonly (keyof Props & string)[],
+> {
+  name: N;
+  description: string;
+  parameters: AiToolParameters<Props, Req>;
+}
+
+export function defineTool<
+  N extends string,
+  Props extends Record<string, JsonSchemaProperty>,
+  const Req extends readonly (keyof Props & string)[],
+>(tool: {
+  name: N;
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Props;
+    required: Req;
+  };
+}): AiToolDefinition<N, Props, Req> {
+  return tool;
+}
+
+type JsonSchemaTypeMap = {
+  string: string;
+  number: number;
+  boolean: boolean;
+  array: unknown[];
+  object: Record<string, unknown>;
+};
+
+export type InferToolArgs<T> = T extends AiToolDefinition<
+  string,
+  infer Props,
+  infer Req
+>
+  ? Req extends readonly (infer R extends keyof Props & string)[]
+    ? { [K in R]: JsonSchemaTypeMap[Props[K]["type"]] } &
+      { [K in Exclude<keyof Props & string, R>]?: JsonSchemaTypeMap[Props[K]["type"]] }
+    : never
+  : never;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyAiToolDefinition = AiToolDefinition<string, any, any>;
 
 export interface AiResponse {
   content?: string | null;
@@ -112,7 +173,7 @@ export async function getEnvProviderConfig(
 
 export async function chatCompletion(
   messages: AiMessage[],
-  tools: AiToolDefinition[] | undefined,
+  tools: AnyAiToolDefinition[] | undefined,
   config: ProviderConfig
 ): Promise<AiResponse> {
   const timeout = parseInt(process.env.AI_TIMEOUT || "30000", 10);
@@ -133,7 +194,7 @@ export async function chatCompletion(
 async function openaiCompatibleCompletion(
   config: ProviderConfig,
   messages: AiMessage[],
-  tools?: AiToolDefinition[],
+  tools?: AnyAiToolDefinition[],
   timeout = 30000
 ): Promise<AiResponse> {
   const baseUrl =
@@ -236,7 +297,7 @@ interface AnthropicMessage {
 async function anthropicCompletion(
   config: ProviderConfig,
   messages: AiMessage[],
-  tools?: AiToolDefinition[],
+  tools?: AnyAiToolDefinition[],
   timeout = 30000
 ): Promise<AiResponse> {
   const model =

--- a/erp/src/lib/ai/tools.ts
+++ b/erp/src/lib/ai/tools.ts
@@ -1,14 +1,17 @@
-
-
 // NOTE: "use server" is intentionally omitted here.
 // This module only exports pure constant definitions (AiToolDefinition objects).
 // No server-side I/O, Prisma, or secrets are used, so it is safe to import
 // from both server and client contexts (e.g. for type inference).
-import type { AiToolDefinition } from "./provider";
+import { defineTool, type AnyAiToolDefinition, type InferToolArgs } from "./provider";
 
 // ─── Tool Definitions ────────────────────────────────────────────────────────
+//
+// Each tool is defined via defineTool() which provides compile-time checks:
+//   1. name is inferred as a string literal type
+//   2. Every entry in required must be a key of properties
+//   3. Typos in required produce TS errors immediately
 
-export const SEARCH_DOCUMENTS: AiToolDefinition = {
+export const SEARCH_DOCUMENTS = defineTool({
   name: "SEARCH_DOCUMENTS",
   description:
     "Busca documentos relevantes na base de conhecimento da empresa. Use para encontrar informacoes sobre produtos, servicos, politicas, procedimentos ou qualquer outro conteudo que possa ajudar a responder o cliente.",
@@ -22,9 +25,9 @@ export const SEARCH_DOCUMENTS: AiToolDefinition = {
     },
     required: ["query"],
   },
-};
+});
 
-export const GET_CLIENT_INFO: AiToolDefinition = {
+export const GET_CLIENT_INFO = defineTool({
   name: "GET_CLIENT_INFO",
   description:
     "Busca dados do cliente vinculado ao ticket atual, incluindo nome, email, telefone, empresa, e informacoes financeiras como titulos a receber pendentes e vencidos. Nao requer parametros — usa o contexto do ticket.",
@@ -33,9 +36,9 @@ export const GET_CLIENT_INFO: AiToolDefinition = {
     properties: {},
     required: [],
   },
-};
+});
 
-export const GET_HISTORY: AiToolDefinition = {
+export const GET_HISTORY = defineTool({
   name: "GET_HISTORY",
   description:
     "Busca o historico recente de mensagens da conversa do ticket atual. Util para entender o contexto da conversa antes de responder.",
@@ -50,9 +53,9 @@ export const GET_HISTORY: AiToolDefinition = {
     },
     required: [],
   },
-};
+});
 
-export const RESPOND: AiToolDefinition = {
+export const RESPOND = defineTool({
   name: "RESPOND",
   description:
     "Envia uma resposta ao cliente via WhatsApp. Use esta ferramenta quando tiver uma resposta pronta para o cliente. A mensagem sera enviada diretamente pelo WhatsApp e registrada no ticket.",
@@ -66,9 +69,9 @@ export const RESPOND: AiToolDefinition = {
     },
     required: ["message"],
   },
-};
+});
 
-export const RESPOND_EMAIL: AiToolDefinition = {
+export const RESPOND_EMAIL = defineTool({
   name: "RESPOND_EMAIL",
   description:
     "Envia uma resposta ao cliente por email. Use quando o canal for email. A mensagem sera enviada por email e registrada no ticket.",
@@ -86,9 +89,9 @@ export const RESPOND_EMAIL: AiToolDefinition = {
     },
     required: ["subject", "message"],
   },
-};
+});
 
-export const ESCALATE: AiToolDefinition = {
+export const ESCALATE = defineTool({
   name: "ESCALATE",
   description:
     "Escala o atendimento para um atendente humano. Use quando o cliente solicitar falar com um humano, quando o problema for muito complexo para o AI resolver, ou quando uma palavra-chave de escalacao for detectada.",
@@ -103,9 +106,9 @@ export const ESCALATE: AiToolDefinition = {
     },
     required: ["reason"],
   },
-};
+});
 
-export const CREATE_NOTE: AiToolDefinition = {
+export const CREATE_NOTE = defineTool({
   name: "CREATE_NOTE",
   description:
     "Cria uma nota interna no ticket. Notas internas sao visiveis apenas para atendentes, nao para o cliente. Use para registrar observacoes, resumos ou informacoes relevantes sobre o atendimento.",
@@ -119,11 +122,33 @@ export const CREATE_NOTE: AiToolDefinition = {
     },
     required: ["content"],
   },
-};
+});
+
+// ─── Inferred argument types (re-export for consumers) ───────────────────────
+
+export type SearchDocumentsArgs = InferToolArgs<typeof SEARCH_DOCUMENTS>;
+export type GetClientInfoArgs = InferToolArgs<typeof GET_CLIENT_INFO>;
+export type GetHistoryArgs = InferToolArgs<typeof GET_HISTORY>;
+export type RespondArgs = InferToolArgs<typeof RESPOND>;
+export type RespondEmailArgs = InferToolArgs<typeof RESPOND_EMAIL>;
+export type EscalateArgs = InferToolArgs<typeof ESCALATE>;
+export type CreateNoteArgs = InferToolArgs<typeof CREATE_NOTE>;
+
+// ─── Tool name union type ────────────────────────────────────────────────────
+
+/** Union of all known tool names — useful for exhaustive switches. */
+export type ToolName =
+  | typeof SEARCH_DOCUMENTS.name
+  | typeof GET_CLIENT_INFO.name
+  | typeof GET_HISTORY.name
+  | typeof RESPOND.name
+  | typeof RESPOND_EMAIL.name
+  | typeof ESCALATE.name
+  | typeof CREATE_NOTE.name;
 
 // ─── All Tools (legacy — includes WhatsApp RESPOND) ─────────────────────────
 
-export const ALL_TOOLS: AiToolDefinition[] = [
+export const ALL_TOOLS: AnyAiToolDefinition[] = [
   SEARCH_DOCUMENTS,
   GET_CLIENT_INFO,
   GET_HISTORY,
@@ -134,7 +159,7 @@ export const ALL_TOOLS: AiToolDefinition[] = [
 
 // ─── Shared (non-terminal) tools ─────────────────────────────────────────────
 
-const SHARED_TOOLS: AiToolDefinition[] = [
+const SHARED_TOOLS: AnyAiToolDefinition[] = [
   SEARCH_DOCUMENTS,
   GET_CLIENT_INFO,
   GET_HISTORY,
@@ -144,12 +169,12 @@ const SHARED_TOOLS: AiToolDefinition[] = [
 
 // ─── Channel-specific tool sets ──────────────────────────────────────────────
 
-export const WHATSAPP_TOOLS: AiToolDefinition[] = [
+export const WHATSAPP_TOOLS: AnyAiToolDefinition[] = [
   ...SHARED_TOOLS,
   RESPOND,
 ];
 
-export const EMAIL_TOOLS: AiToolDefinition[] = [
+export const EMAIL_TOOLS: AnyAiToolDefinition[] = [
   ...SHARED_TOOLS,
   RESPOND_EMAIL,
 ];
@@ -157,6 +182,6 @@ export const EMAIL_TOOLS: AiToolDefinition[] = [
 /**
  * Returns the appropriate tool set for a given channel.
  */
-export function getToolsForChannel(channel: "WHATSAPP" | "EMAIL"): AiToolDefinition[] {
+export function getToolsForChannel(channel: "WHATSAPP" | "EMAIL"): AnyAiToolDefinition[] {
   return channel === "EMAIL" ? EMAIL_TOOLS : WHATSAPP_TOOLS;
 }


### PR DESCRIPTION
## What

Replace weak `Record<string, unknown>` parameters in `AiToolDefinition` with strongly-typed generics that validate required parameters at compile-time.

## Changes

### `provider.ts`
- `JsonSchemaProperty` — typed JSON-Schema property descriptor
- `AiToolParameters<Props, Req>` — generic parameters with validated `required` tuple
- `AiToolDefinition<N, Props, Req>` — generic tool definition (backward-compatible defaults)
- `defineTool()` — helper function that infers literal name and checks `required` entries against `properties` keys
- `InferToolArgs<T>` — utility type to extract parsed argument types from a tool definition
- `AnyAiToolDefinition` — loose type alias for arrays/runtime dispatch

### `tools.ts`
- All 7 tool definitions migrated to `defineTool()` 
- Exported per-tool arg types: `SearchDocumentsArgs`, `RespondArgs`, `RespondEmailArgs`, etc.
- Exported `ToolName` union type for exhaustive switch/case
- Arrays use `AnyAiToolDefinition[]` for compatibility

## How it works

```typescript
// Before: no compile-time validation
const BAD_TOOL: AiToolDefinition = {
  name: "X",
  description: "...",
  parameters: { type: "object", properties: { a: { type: "string" } }, required: ["typo"] } // no error!
};

// After: TS error if required key is not in properties
const BAD_TOOL = defineTool({
  name: "X",
  description: "...",
  parameters: { type: "object", properties: { a: { type: "string" } }, required: ["typo"] } // TS Error!
});

// Extract typed args
type Args = InferToolArgs<typeof RESPOND>; // { message: string }
```

## Backward compatibility

- Runtime JSON structure is unchanged (same shape sent to OpenAI/Anthropic)
- `AiToolDefinition` defaults maintain backward compat for untyped usage
- Existing tests pass without modification

Fixes #233