### PR TITLE
fix: lazy-load MockProvider via dynamic import (#114)

### DIFF
--- a/erp/src/app/(app)/comercial/propostas/actions.ts
+++ b/erp/src/app/(app)/comercial/propostas/actions.ts
@@ -630,7 +630,7 @@ async function resolveGatewayForBoleto(
     if (!isProviderType(provider.provider)) {
       throw new Error(`Provider inválido encontrado no banco: ${provider.provider}`);
     }
-    const gateway = getGateway(
+    const gateway = await getGateway(
       provider.provider,
       decryptedCredentials,
       metadata,
@@ -655,7 +655,7 @@ async function resolveGatewayForBoleto(
     logger.warn(
       `[Payment] Nenhum provider configurado para empresa ${companyId}. Usando mock como fallback.`,
     );
-    const gateway = getGateway("mock", {});
+    const gateway = await getGateway("mock", {});
     return {
       gateway,
       providerId: null,
@@ -671,7 +671,7 @@ async function resolveGatewayForBoleto(
   if (!isProviderType(provider.provider)) {
     throw new Error(`Provider inválido encontrado no banco: ${provider.provider}`);
   }
-  const gateway = getGateway(
+  const gateway = await getGateway(
     provider.provider,
     decryptedCredentials,
     metadata,

--- a/erp/src/app/(app)/configuracoes/integracoes-bancarias/actions.ts
+++ b/erp/src/app/(app)/configuracoes/integracoes-bancarias/actions.ts
@@ -424,7 +424,7 @@ export async function testProviderConnection(
     if (!isProviderType(provider.provider)) {
       return { ok: false, message: `Provider inválido encontrado no banco: ${provider.provider}` };
     }
-    const gateway = getGateway(
+    const gateway = await getGateway(
       provider.provider,
       decryptedCredentials,
       provider.metadata as Record<string, unknown> | null,

--- a/erp/src/app/api/boletos/[boletoId]/pdf/route.ts
+++ b/erp/src/app/api/boletos/[boletoId]/pdf/route.ts
@@ -118,7 +118,7 @@ export async function GET(
     ) as Record<string, unknown>;
     const metadata = provider.metadata as Record<string, unknown> | null;
 
-    const gateway = getGateway(
+    const gateway = await getGateway(
       provider.provider,
       decryptedCredentials,
       metadata,

--- a/erp/src/app/api/webhooks/payment/[provider]/route.ts
+++ b/erp/src/app/api/webhooks/payment/[provider]/route.ts
@@ -78,7 +78,7 @@ export async function POST(
 
   // 4. Try to validate signature with each provider's webhookSecret
   let matchedProvider: (typeof providers)[number] | null = null;
-  let gateway: ReturnType<typeof getGateway> | null = null;
+  let gateway: Awaited<ReturnType<typeof getGateway>> | null = null;
 
   for (const prov of providers) {
     try {
@@ -92,7 +92,7 @@ export async function POST(
       if (!isProviderType(prov.provider)) {
         throw new Error(`Provider inválido encontrado no banco: ${prov.provider}`);
       }
-      const gw = getGateway(
+      const gw = await getGateway(
         prov.provider,
         decryptedCredentials,
         metadata,

--- a/erp/src/app/api/webhooks/santander/[providerId]/route.ts
+++ b/erp/src/app/api/webhooks/santander/[providerId]/route.ts
@@ -58,7 +58,7 @@ export async function POST(
   }
 
   // 4. Instantiate gateway and validate webhook
-  let gateway: ReturnType<typeof getGateway>;
+  let gateway: Awaited<ReturnType<typeof getGateway>>;
   try {
     const decryptedCredentials = JSON.parse(
       decrypt(provider.credentials),
@@ -66,7 +66,7 @@ export async function POST(
 
     const metadata = provider.metadata as Record<string, unknown> | null;
 
-    gateway = getGateway(
+    gateway = await getGateway(
       "santander",
       decryptedCredentials,
       metadata,

--- a/erp/src/lib/payment/factory.ts
+++ b/erp/src/lib/payment/factory.ts
@@ -1,6 +1,5 @@
 import type { PaymentGateway } from "./types";
 import { PROVIDER_REGISTRY } from "./registry";
-import { MockProvider } from "./providers/mock.provider";
 import { PagarmeProvider } from "./providers/pagarme.provider";
 import { SantanderProvider } from "./providers/santander.provider";
 import type { SantanderCredentials } from "./providers/santander-auth";
@@ -31,10 +30,13 @@ type GatewayFactory = (
   metadata: Record<string, unknown> | null | undefined,
   webhookSecret: string | undefined,
   options: GatewayOptions | undefined,
-) => PaymentGateway;
+) => PaymentGateway | Promise<PaymentGateway>;
 
 const GATEWAY_FACTORIES: Record<string, GatewayFactory> = {
-  mock: () => new MockProvider(),
+  mock: async () => {
+    const { MockProvider } = await import("./providers/mock.provider");
+    return new MockProvider();
+  },
 
   pagarme: (decryptedCredentials, metadata, webhookSecret) => {
     // Bug #17 fix: Validate required credential fields before instantiation
@@ -94,7 +96,7 @@ const GATEWAY_FACTORIES: Record<string, GatewayFactory> = {
 };
 
 // ---------------------------------------------------------------------------
-// getGateway — public API (unchanged signature for backward compatibility)
+// getGateway — public API
 // ---------------------------------------------------------------------------
 
 /**
@@ -103,6 +105,9 @@ const GATEWAY_FACTORIES: Record<string, GatewayFactory> = {
  * Uses a registry-based factory pattern: each provider registers a factory
  * function in GATEWAY_FACTORIES. Adding a new provider requires only adding
  * an entry — no switch/case modification needed.
+ *
+ * Now async to support dynamic imports (e.g. MockProvider is lazy-loaded
+ * so it never ends up in the production bundle).
  *
  * @param providerType - Tipo do provider ("pagarme" | "pinbank" | "santander" | "mock")
  * @param decryptedCredentials - Credentials já decriptadas (JSON parseado)
@@ -114,13 +119,13 @@ const GATEWAY_FACTORIES: Record<string, GatewayFactory> = {
  * @throws Error se o provider não existir no registry
  * @throws Error se o provider ainda não estiver implementado
  */
-export function getGateway(
+export async function getGateway(
   providerType: string,
   decryptedCredentials: Record<string, unknown>,
   metadata?: Record<string, unknown> | null,
   webhookSecret?: string,
   options?: GatewayOptions,
-): PaymentGateway {
+): Promise<PaymentGateway> {
   if (!PROVIDER_REGISTRY[providerType]) {
     throw new Error(`Provider not found: ${providerType}`);
   }


### PR DESCRIPTION
## Problema

`MockProvider` era importado incondicionalmente no topo de `factory.ts`, incluindo-o no bundle de produção mesmo quando nunca utilizado.

## Solução

- Removido o `import { MockProvider }` estático
- Factory `mock` agora usa `await import("./providers/mock.provider")` (dynamic import)
- `getGateway()` agora é `async` retornando `Promise<PaymentGateway>`
- Todos os call sites atualizados com `await`
- Type annotations `ReturnType<typeof getGateway>` → `Awaited<ReturnType<typeof getGateway>>`

## Arquivos alterados

- `erp/src/lib/payment/factory.ts` — core fix
- `erp/src/app/(app)/comercial/propostas/actions.ts` — await
- `erp/src/app/(app)/configuracoes/integracoes-bancarias/actions.ts` — await
- `erp/src/app/api/boletos/[boletoId]/pdf/route.ts` — await
- `erp/src/app/api/webhooks/payment/[provider]/route.ts` — await + type
- `erp/src/app/api/webhooks/santander/[providerId]/route.ts` — await + type

Fixes #114