### PR TITLE
fix: remove sync re-exports from "use server" embeddings.ts

### DIFF
--- a/erp/src/lib/ai/embeddings.ts
+++ b/erp/src/lib/ai/embeddings.ts
@@ -4,8 +4,7 @@
 import { prisma } from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { isGlobalFallbackBlocked } from "./provider";
-import { chunkText, cosineSimilarity } from "@/lib/ai/embedding-utils";
-export { chunkText, cosineSimilarity };
+import { cosineSimilarity } from "@/lib/ai/embedding-utils";
 
 // ─── Configuration ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

`embeddings.ts` has the `"use server"` directive but re-exports `chunkText` and `cosineSimilarity` which are **synchronous functions** from `embedding-utils.ts`. Next.js requires all exports from `"use server"` files to be async (server actions).

## Fix

- Removed the `export { chunkText, cosineSimilarity }` re-export line
- Kept the import of `cosineSimilarity` (used internally by `searchDocuments`)
- Removed unused `chunkText` import
- All consumers already import these utils directly from `@/lib/ai/embedding-utils`

Fixes #97