### PR TITLE
fix: add DeepSeek test coverage for model-suggester (#92)

### DIFF
--- a/erp/src/lib/ai/__tests__/model-suggester.test.ts
+++ b/erp/src/lib/ai/__tests__/model-suggester.test.ts
@@ -45,6 +45,26 @@ describe("suggestModel", () => {
     });
   });
 
+  describe("deepseek provider", () => {
+    it("returns deepseek-chat as fallback when budget is near zero", () => {
+      const result = suggestModel("deepseek", 0.001);
+      expect(result.model).toBe("deepseek-chat");
+      expect(result.estimatedDailyCostBrl).toBeGreaterThan(0);
+    });
+
+    it("returns deepseek-reasoner when budget is high enough", () => {
+      const reasonerCost = dailyCostBrl("deepseek-reasoner");
+      const result = suggestModel("deepseek", reasonerCost + 1);
+      expect(result.model).toBe("deepseek-reasoner");
+    });
+
+    it("returns a valid deepseek model for any budget", () => {
+      const result = suggestModel("deepseek", 100);
+      expect(["deepseek-reasoner", "deepseek-chat"]).toContain(result.model);
+      expect(result.estimatedDailyCostBrl).toBeGreaterThan(0);
+    });
+  });
+
   describe("unknown provider", () => {
     it("returns a fallback model", () => {
       const result = suggestModel("unknown-provider", 100);


### PR DESCRIPTION
## Contexto

A issue #92 reportou que DeepSeek estaria ausente de `PROVIDER_MODELS` no `model-suggester.ts`.

## Investigação

`PROVIDER_MODELS` foi refatorado para `STATIC_MODELS` e movido para `model-discovery.ts` no PR #326. **DeepSeek já estava presente** nessa refatoração:

```ts
// model-discovery.ts
export const STATIC_MODELS: Record<string, string[]> = {
  // ...
  deepseek: ["deepseek-reasoner", "deepseek-chat"],
};
```

Também já existia em:
- `MODEL_PRICING` (pricing.ts) — com preços de deepseek-chat e deepseek-reasoner
- `VALID_PROVIDERS` (actions.ts) — inclui "deepseek"
- Frontend `PROVIDERS` (types.ts) — inclui DeepSeek
- `PROVIDER_ENDPOINTS` e `MODEL_FILTERS` (model-discovery.ts)

## O que faltava

Cobertura de testes. O `model-suggester.test.ts` testava openai, anthropic, qwen e unknown provider, mas **não tinha testes para deepseek**.

## Mudanças

Adicionado `describe("deepseek provider")` com 3 test cases:
- `deepseek-chat` como fallback com budget mínimo
- `deepseek-reasoner` selecionado quando budget permite
- Modelo válido retornado para qualquer budget

Fixes #92