### PR TITLE
fix: ensure DeepSeek provider parity between frontend and backend

### DIFF
--- a/erp/src/app/(app)/configuracoes/ai/__tests__/actions.test.ts
+++ b/erp/src/app/(app)/configuracoes/ai/__tests__/actions.test.ts
@@ -503,3 +503,48 @@ describe("updateAiConfig", () => {
     ).resolves.not.toThrow();
   });
 });
+
+// ─── Provider parity (issue #80) ─────────────────────────────────────────────
+describe("Provider parity — frontend ↔ backend", () => {
+  it("PROVIDERS (frontend) matches VALID_PROVIDERS (backend)", async () => {
+    const { PROVIDERS } = await import(
+      "@/app/(app)/configuracoes/ai/components/types"
+    );
+
+    // VALID_PROVIDERS is not exported, so we extract it indirectly:
+    // updateAiConfig rejects unknown providers with a message listing them.
+    const { updateAiConfig } = await import(
+      "@/app/(app)/configuracoes/ai/actions"
+    );
+
+    let errorMsg = "";
+    try {
+      await updateAiConfig("company-1", {
+        enabled: true,
+        persona: "test",
+        welcomeMessage: "hi",
+        escalationKeywords: [],
+        maxIterations: 5,
+        provider: "__invalid_provider__" as never,
+        apiKey: "sk-test",
+        model: "gpt-4o",
+        whatsappEnabled: true,
+        emailEnabled: false,
+        emailPersona: "",
+        emailSignature: "",
+        dailySpendLimitBrl: null,
+        temperature: 0.7,
+      });
+    } catch (e: unknown) {
+      errorMsg = (e as Error).message;
+    }
+
+    // Extract valid providers from error message: "provider must be one of: openai, anthropic, ..."
+    const match = errorMsg.match(/provider must be one of: (.+)/);
+    expect(match).not.toBeNull();
+    const backendProviders = match![1].split(", ").sort();
+    const frontendProviders = PROVIDERS.map((p) => p.value).sort();
+
+    expect(frontendProviders).toEqual(backendProviders);
+  });
+});

--- a/erp/src/app/(app)/configuracoes/ai/components/types.ts
+++ b/erp/src/app/(app)/configuracoes/ai/components/types.ts
@@ -2,6 +2,11 @@ import type { AiConfigData, UsageSummary, ModelSuggestionData, SimulationResult 
 
 export type { AiConfigData, UsageSummary, ModelSuggestionData, SimulationResult };
 
+/**
+ * Frontend provider selector options.
+ * Must stay in sync with VALID_PROVIDERS in actions.ts (backend).
+ * See issue #80 for context on the consistency requirement.
+ */
 export const PROVIDERS = [
   { value: "openai", label: "OpenAI" },
   { value: "anthropic", label: "Anthropic" },


### PR DESCRIPTION
## Summary

Closes #80 — Tech Debt: DeepSeek accepted in backend (`VALID_PROVIDERS`) but missing from frontend selector.

### Finding

DeepSeek was already added to the frontend `PROVIDERS` array during the component decomposition refactor in PR #194. The inconsistency described in #80 no longer exists in `main`.

### What this PR adds

1. **Documentation comment** on `PROVIDERS` in `types.ts` — explicitly notes the sync requirement with `VALID_PROVIDERS` in `actions.ts` and references issue #80
2. **Parity test** — a new test in `actions.test.ts` that verifies frontend `PROVIDERS` matches backend `VALID_PROVIDERS`, preventing future drift

### Verification

- `VALID_PROVIDERS` (backend): `openai, anthropic, grok, qwen, deepseek` ✅
- `PROVIDERS` (frontend): `openai, anthropic, grok, qwen, deepseek` ✅

### Acceptance Criteria from #80

- [x] Consistency between `VALID_PROVIDERS` and frontend provider selector
- [x] DeepSeek appears in selector with label and available models
- [x] Guard test prevents future drift