### PR TITLE
fix: use DATABASE_URL fallback in prisma.config.ts for generate without env

### DIFF
--- a/erp/prisma.config.ts
+++ b/erp/prisma.config.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -7,6 +7,6 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env.DATABASE_URL ?? "postgresql://placeholder:placeholder@localhost:5432/placeholder",
   },
 });


### PR DESCRIPTION
## Summary

Replace Prisma's `env()` helper (which throws `PrismaConfigEnvError` when `DATABASE_URL` is missing) with `process.env.DATABASE_URL` and a placeholder fallback.

## Changes

- **`erp/prisma.config.ts`**: Use `process.env.DATABASE_URL ?? "postgresql://placeholder:..."` instead of `env("DATABASE_URL")`
- Removed unused `env` import from `prisma/config`

## Why

`prisma generate` only needs a valid URL format to generate types — it never connects to the database. The previous `env()` call threw `PrismaConfigEnvError` in any environment without `DATABASE_URL` (CI, clean clones, onboarding).

The `|| true` pattern (mentioned in the issue) masked this failure, causing downstream TypeScript errors like `Module @prisma/client has no exported member X`.

## Acceptance Criteria

- [x] `npm install` in environment without `DATABASE_URL` generates Prisma Client correctly
- [x] `npm run build` passes after clean `npm install`
- [x] No `|| true` suppressing critical type generation errors

Fixes #70