### PR TITLE
refactor: replace Prisma.Decimal with decimal.js

### DIFF
--- a/erp/package-lock.json
+++ b/erp/package-lock.json
@@ -21,11 +21,11 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
-        "@types/sanitize-html": "^2.16.1",
         "bcryptjs": "^3.0.3",
         "bullmq": "^5.70.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "decimal.js": "^10.6.0",
         "dotenv": "^17.3.1",
         "imapflow": "^1.2.10",
         "ioredis": "^5.10.0",
@@ -48,6 +48,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
+        "undici": "^7.21.0",
         "xlsx": "^0.18.5",
         "xml-crypto": "^6.1.2"
       },
@@ -61,6 +62,7 @@
         "@types/nodemailer": "^7.0.11",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/sanitize-html": "^2.16.1",
         "eslint": "^8",
         "eslint-config-next": "14.2.35",
         "jsdom": "^28.1.0",
@@ -3383,6 +3385,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
       "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "htmlparser2": "^10.1"
@@ -5413,7 +5416,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -7225,6 +7227,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
       "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -7244,6 +7247,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11479,7 +11483,6 @@
       "version": "7.22.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
       "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/erp/package.json
+++ b/erp/package.json
@@ -28,6 +28,7 @@
     "bullmq": "^5.70.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "decimal.js": "^10.6.0",
     "dotenv": "^17.3.1",
     "imapflow": "^1.2.10",
     "ioredis": "^5.10.0",

--- a/erp/src/app/(app)/comercial/pipeline/actions.ts
+++ b/erp/src/app/(app)/comercial/pipeline/actions.ts
@@ -3,6 +3,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireCompanyAccess } from "@/lib/rbac";
 import { Prisma } from "@prisma/client";
+import Decimal from "decimal.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -83,10 +84,10 @@ export async function listPipelineData(
   if (filters.valueMin !== undefined || filters.valueMax !== undefined) {
     where.totalValue = {};
     if (filters.valueMin !== undefined) {
-      where.totalValue.gte = new Prisma.Decimal(filters.valueMin);
+      where.totalValue.gte = new Decimal(filters.valueMin);
     }
     if (filters.valueMax !== undefined) {
-      where.totalValue.lte = new Prisma.Decimal(filters.valueMax);
+      where.totalValue.lte = new Decimal(filters.valueMax);
     }
   }
 

--- a/erp/src/app/(app)/comercial/propostas/actions.ts
+++ b/erp/src/app/(app)/comercial/propostas/actions.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { requireCompanyAccess } from "@/lib/rbac";
 import { logAuditEvent } from "@/lib/audit";
 import { Prisma, type ProposalStatus, type BoletoStatus } from "@prisma/client";
+import Decimal from "decimal.js";
 import { getSharedCompanyIds } from "@/lib/shared-clients";
 import { getCachedFiscalConfig } from "@/app/(app)/configuracoes/fiscal/actions";
 import { emitInvoiceForBoleto } from "@/lib/nfse-actions";
@@ -130,11 +131,11 @@ const VALID_STATUS_TRANSITIONS: Record<ProposalStatus, ProposalStatus[]> = {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function calculateTotalValue(items: ProposalItemInput[]): Prisma.Decimal {
-  let total = new Prisma.Decimal(0);
+function calculateTotalValue(items: ProposalItemInput[]): Decimal {
+  let total = new Decimal(0);
   for (const item of items) {
-    const qty = new Prisma.Decimal(item.quantity);
-    const price = new Prisma.Decimal(item.unitPrice);
+    const qty = new Decimal(item.quantity);
+    const price = new Decimal(item.unitPrice);
     total = total.add(qty.mul(price));
   }
   return total;
@@ -220,10 +221,10 @@ export async function listProposals(
   if (params.valueMin !== undefined || params.valueMax !== undefined) {
     where.totalValue = {};
     if (params.valueMin !== undefined) {
-      where.totalValue.gte = new Prisma.Decimal(params.valueMin);
+      where.totalValue.gte = new Decimal(params.valueMin);
     }
     if (params.valueMax !== undefined) {
-      where.totalValue.lte = new Prisma.Decimal(params.valueMax);
+      where.totalValue.lte = new Decimal(params.valueMax);
     }
   }
 
@@ -293,8 +294,8 @@ export async function createProposal(
       items: {
         create: input.items.map((item) => ({
           description: item.description.trim(),
-          quantity: new Prisma.Decimal(item.quantity),
-          unitPrice: new Prisma.Decimal(item.unitPrice),
+          quantity: new Decimal(item.quantity),
+          unitPrice: new Decimal(item.unitPrice),
         })),
       },
     },
@@ -373,8 +374,8 @@ export async function updateProposal(
         items: {
           create: input.items.map((item) => ({
             description: item.description.trim(),
-            quantity: new Prisma.Decimal(item.quantity),
-            unitPrice: new Prisma.Decimal(item.unitPrice),
+            quantity: new Decimal(item.quantity),
+            unitPrice: new Decimal(item.unitPrice),
           })),
         },
       },
@@ -871,7 +872,7 @@ export async function generateBoletosForProposal(
           gatewayId: result.gatewayId,
           gatewayData: gatewayData as unknown as Prisma.InputJsonValue,
           manualOverride,
-          value: new Prisma.Decimal(value),
+          value: new Decimal(value),
           dueDate,
           installmentNumber: i,
           status: "GENERATED",
@@ -884,7 +885,7 @@ export async function generateBoletosForProposal(
         data: {
           clientId: proposal.clientId,
           description: `Boleto ${i}/${input.installments} - Proposta #${proposal.id.slice(-6)}`,
-          value: new Prisma.Decimal(value),
+          value: new Decimal(value),
           dueDate,
           status: "PENDING",
           companyId: input.companyId,

--- a/erp/src/app/(app)/dashboard/actions.ts
+++ b/erp/src/app/(app)/dashboard/actions.ts
@@ -3,6 +3,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireSession } from "@/lib/session";
 import { Prisma } from "@prisma/client";
+import type Decimal from "decimal.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -343,7 +344,7 @@ export async function getDashboardData(filters: DashboardFilters): Promise<Dashb
     }),
 
     // Monthly revenue — uses period-aware date range
-    prisma.$queryRaw<{ month: Date; total: Prisma.Decimal }[]>`
+    prisma.$queryRaw<{ month: Date; total: Decimal }[]>`
       SELECT date_trunc('month', "paidAt") AS month, SUM(value) AS total
       FROM accounts_receivable
       WHERE "companyId" = ANY(${companyIds})
@@ -355,7 +356,7 @@ export async function getDashboardData(filters: DashboardFilters): Promise<Dashb
     `,
 
     // Monthly expenses — uses period-aware date range
-    prisma.$queryRaw<{ month: Date; total: Prisma.Decimal }[]>`
+    prisma.$queryRaw<{ month: Date; total: Decimal }[]>`
       SELECT date_trunc('month', "paidAt") AS month, SUM(value) AS total
       FROM accounts_payable
       WHERE "companyId" = ANY(${companyIds})
@@ -647,7 +648,7 @@ export async function getRevenueExpenseChart(): Promise<MonthlyChartEntry[]> {
   ];
 
   const [monthlyRevenue, monthlyExpenses] = await Promise.all([
-    prisma.$queryRaw<{ month: Date; total: Prisma.Decimal }[]>`
+    prisma.$queryRaw<{ month: Date; total: Decimal }[]>`
       SELECT date_trunc('month', "paidAt") AS month, SUM(value) AS total
       FROM accounts_receivable
       WHERE "companyId" = ANY(${companyIds})
@@ -657,7 +658,7 @@ export async function getRevenueExpenseChart(): Promise<MonthlyChartEntry[]> {
       GROUP BY date_trunc('month', "paidAt")
       ORDER BY month
     `,
-    prisma.$queryRaw<{ month: Date; total: Prisma.Decimal }[]>`
+    prisma.$queryRaw<{ month: Date; total: Decimal }[]>`
       SELECT date_trunc('month', "paidAt") AS month, SUM(value) AS total
       FROM accounts_payable
       WHERE "companyId" = ANY(${companyIds})

--- a/erp/src/app/(app)/financeiro/conciliacao/actions.ts
+++ b/erp/src/app/(app)/financeiro/conciliacao/actions.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { requireCompanyAccess } from "@/lib/rbac";
 import { logAuditEvent } from "@/lib/audit";
 import { Prisma, type BankTransactionStatus, type PaymentStatus } from "@prisma/client";
+import Decimal from "decimal.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -296,7 +297,7 @@ export async function importBankTransactions(
         data: {
           date: trx.date,
           description: trx.description || "Sem descrição",
-          value: new Prisma.Decimal(trx.value),
+          value: new Decimal(trx.value),
           companyId,
         },
       });

--- a/erp/src/app/(app)/financeiro/pagar/actions.ts
+++ b/erp/src/app/(app)/financeiro/pagar/actions.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { requireCompanyAccess } from "@/lib/rbac";
 import { logAuditEvent } from "@/lib/audit";
 import { Prisma, type PaymentStatus, type Recurrence } from "@prisma/client";
+import Decimal from "decimal.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -239,7 +240,7 @@ export async function createPayable(input: CreatePayableInput) {
     data: {
       supplier: input.supplier.trim(),
       description: input.description.trim(),
-      value: new Prisma.Decimal(input.value),
+      value: new Decimal(input.value),
       dueDate: new Date(input.dueDate),
       categoryId: input.categoryId || null,
       recurrence: input.recurrence || "NONE",
@@ -305,7 +306,7 @@ export async function updatePayable(input: UpdatePayableInput) {
     data: {
       supplier: input.supplier.trim(),
       description: input.description.trim(),
-      value: new Prisma.Decimal(input.value),
+      value: new Decimal(input.value),
       dueDate: new Date(input.dueDate),
       categoryId: input.categoryId || null,
       recurrence: input.recurrence || "NONE",

--- a/erp/src/app/(app)/financeiro/receber/__tests__/actions.test.ts
+++ b/erp/src/app/(app)/financeiro/receber/__tests__/actions.test.ts
@@ -20,23 +20,10 @@ vi.mock("@/lib/shared-clients", () => ({
   getSharedCompanyIds: (...args: unknown[]) => mockGetSharedCompanyIds(...args),
 }));
 
-// Mock @prisma/client to avoid loading the real Prisma runtime in unit tests.
-// Prisma.Decimal is used inside createReceivable — we provide a lightweight stub.
-vi.mock("@prisma/client", async () => {
-  class DecimalStub {
-    private val: string;
-    constructor(v: number | string) {
-      this.val = String(v);
-    }
-    toString() {
-      return this.val;
-    }
-  }
-  return {
-    Prisma: { Decimal: DecimalStub },
-    // Expose commonly referenced enums/types as needed
-  };
-});
+// Mock @prisma/client — Prisma.Decimal no longer needed (replaced by decimal.js)
+vi.mock("@prisma/client", async () => ({
+  Prisma: {},
+}));
 
 const mockFindMany = vi.fn();
 const mockCount = vi.fn();

--- a/erp/src/app/(app)/financeiro/receber/actions.ts
+++ b/erp/src/app/(app)/financeiro/receber/actions.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { requireCompanyAccess } from "@/lib/rbac";
 import { logAuditEvent } from "@/lib/audit";
 import { Prisma, type PaymentStatus } from "@prisma/client";
+import Decimal from "decimal.js";
 import { getSharedCompanyIds } from "@/lib/shared-clients";
 
 // ---------------------------------------------------------------------------
@@ -161,7 +162,7 @@ export async function createReceivable(input: CreateReceivableInput) {
     data: {
       clientId: input.clientId,
       description: input.description.trim(),
-      value: new Prisma.Decimal(input.value),
+      value: new Decimal(input.value),
       dueDate: new Date(input.dueDate),
       companyId: input.companyId,
     },

--- a/erp/src/app/(app)/fiscal/impostos/actions.ts
+++ b/erp/src/app/(app)/fiscal/impostos/actions.ts
@@ -5,6 +5,7 @@ import { requireCompanyAccess } from "@/lib/rbac";
 import { requireSession } from "@/lib/session";
 import { logAuditEvent } from "@/lib/audit";
 import { type TaxType, type TaxStatus, Prisma } from "@prisma/client";
+import Decimal from "decimal.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -256,7 +257,7 @@ export async function createTaxEntry(input: {
       companyId: input.companyId,
       type: input.type,
       period: input.period,
-      value: new Prisma.Decimal(input.value),
+      value: new Decimal(input.value),
       dueDate: new Date(input.dueDate),
     },
   });

--- a/erp/src/lib/ai/__tests__/cost-tracker.test.ts
+++ b/erp/src/lib/ai/__tests__/cost-tracker.test.ts
@@ -16,15 +16,6 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
-// Prisma Decimal stub — avoids loading the real Prisma runtime
-vi.mock("@prisma/client/runtime/library", () => ({
-  Decimal: class {
-    private val: string;
-    constructor(v: number | string) { this.val = String(v); }
-    toString() { return this.val; }
-  },
-}));
-
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe("cost-tracker", () => {

--- a/erp/src/lib/nfse-actions.ts
+++ b/erp/src/lib/nfse-actions.ts
@@ -10,6 +10,7 @@ import {
   type CompanyBranding,
 } from "@/lib/email-templates";
 import { Prisma } from "@prisma/client";
+import Decimal from "decimal.js";
 import { getCachedFiscalConfig } from "@/app/(app)/configuracoes/fiscal/actions";
 import { createTaxEntriesForInvoice } from "@/lib/tax-entries";
 import { logger } from "@/lib/logger";
@@ -248,8 +249,8 @@ export async function emitInvoiceForBoleto(
       boletoId: boleto.id,
       clientId: client.id,
       serviceDescription,
-      value: new Prisma.Decimal(value),
-      issRate: new Prisma.Decimal(issRate),
+      value: new Decimal(value),
+      issRate: new Decimal(issRate),
       status: "PENDING",
       nfNumber: null,
       companyId,

--- a/erp/src/lib/tax-entries.ts
+++ b/erp/src/lib/tax-entries.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { Prisma, type PrismaClient } from "@prisma/client";
+import Decimal from "decimal.js";
 import type { FiscalConfigData } from "@/app/(app)/configuracoes/fiscal/actions";
 
 // ---------------------------------------------------------------------------
@@ -71,7 +72,7 @@ export async function createTaxEntriesForInvoice(input: TaxEntryInput) {
       invoiceId,
       type: t.type as "ISS" | "PIS" | "COFINS" | "IRPJ" | "CSLL",
       period,
-      value: new Prisma.Decimal(sign * value * (t.rate / 100)),
+      value: new Decimal(sign * value * (t.rate / 100)),
       dueDate,
       status: "PENDING" as const,
     }));


### PR DESCRIPTION
## Summary

Replaces all usages of `Prisma.Decimal` (internal API from `@prisma/client/runtime/library`) with the `decimal.js` package directly.

This eliminates the dependency on Prisma's internal runtime API which is unstable and can break on updates.

## Changes

- **Add `decimal.js`** as a direct dependency in `erp/package.json`
- **Replace `new Prisma.Decimal()`** → `new Decimal()` from `decimal.js` across 9 source files:
  - `tax-entries.ts`, `nfse-actions.ts`
  - `impostos/actions.ts`, `conciliacao/actions.ts`, `pagar/actions.ts`, `receber/actions.ts`
  - `propostas/actions.ts`, `pipeline/actions.ts`, `dashboard/actions.ts`
- **Remove `@prisma/client/runtime/library` mock** from cost-tracker tests
- **Simplify `@prisma/client` mock** in receivable tests (no `Decimal` stub needed)
- **Keep `Prisma` import** where still used for other types (`InputJsonValue`, `WhereInput`, etc.)

## Compatibility

Prisma accepts `decimal.js` instances natively for Decimal fields (it's the same underlying library), so this is a drop-in replacement with no behavior change.

Fixes #98