### PR TITLE
test: add unit tests for provider.ts and agent.ts

### DIFF
--- a/erp/src/lib/ai/__tests__/agent.test.ts
+++ b/erp/src/lib/ai/__tests__/agent.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Unit tests for agent.ts - runAgent and runAgentDryRun.
+ * Fixes https://github.com/diogenesmendes01/MendesAplication/issues/230
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockChatCompletion = vi.fn();
+const mockGetEnvProviderConfig = vi.fn();
+const mockExecuteTool = vi.fn();
+const mockDecrypt = vi.fn((v: string) => `decrypted:${v}`);
+const mockGetTodaySpend = vi.fn().mockResolvedValue(0);
+const mockCheckAndReserveSpend = vi.fn().mockResolvedValue(true);
+const mockLogUsage = vi.fn().mockResolvedValue(undefined);
+const mockGetToolsForChannel = vi.fn().mockReturnValue([]);
+const mockGetBrlUsdRateSync = vi.fn().mockReturnValue(5.0);
+
+const mockPrismaAiConfigFindUnique = vi.fn();
+const mockPrismaTicketFindUnique = vi.fn();
+const mockPrismaTicketUpdate = vi.fn();
+const mockPrismaTicketMessageFindMany = vi.fn().mockResolvedValue([]);
+const mockPrismaTicketMessageCreate = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    aiConfig: { findUnique: (...a: unknown[]) => mockPrismaAiConfigFindUnique(...a) },
+    ticket: {
+      findUnique: (...a: unknown[]) => mockPrismaTicketFindUnique(...a),
+      update: (...a: unknown[]) => mockPrismaTicketUpdate(...a),
+    },
+    ticketMessage: {
+      findMany: (...a: unknown[]) => mockPrismaTicketMessageFindMany(...a),
+      create: (...a: unknown[]) => mockPrismaTicketMessageCreate(...a),
+    },
+  },
+}));
+
+vi.mock("@/lib/ai/provider", () => ({
+  chatCompletion: (...args: unknown[]) => mockChatCompletion(...args),
+  getEnvProviderConfig: () => mockGetEnvProviderConfig(),
+}));
+
+vi.mock("@/lib/ai/tool-executor", () => ({
+  executeTool: (...args: unknown[]) => mockExecuteTool(...args),
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  decrypt: (v: string) => mockDecrypt(v),
+}));
+
+vi.mock("@/lib/ai/cost-tracker", () => ({
+  getTodaySpend: (...args: unknown[]) => mockGetTodaySpend(...args),
+  checkAndReserveSpend: (...args: unknown[]) => mockCheckAndReserveSpend(...args),
+  logUsage: (...args: unknown[]) => mockLogUsage(...args),
+}));
+
+vi.mock("@/lib/ai/tools", () => ({
+  getToolsForChannel: (...args: unknown[]) => mockGetToolsForChannel(...args),
+}));
+
+vi.mock("@/lib/ai/exchange-rate", () => ({
+  getBrlUsdRateSync: () => mockGetBrlUsdRateSync(),
+  getBrlUsdRate: vi.fn().mockResolvedValue(5.0),
+}));
+
+vi.mock("@/lib/ai/pricing", () => ({
+  DEFAULT_MODELS: {
+    openai: "gpt-4o",
+    anthropic: "claude-sonnet-4-20250514",
+    deepseek: "deepseek-chat",
+  } as Record<string, string>,
+  MODEL_PRICING: {
+    "gpt-4o": { input: 2.5, output: 10.0 },
+  } as Record<string, { input: number; output: number }>,
+  FALLBACK_PRICING: { input: 3.0, output: 15.0 },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+  createChildLogger: vi.fn().mockReturnValue({
+    warn: vi.fn(), error: vi.fn(), info: vi.fn(),
+  }),
+}));
+
+import { runAgent, runAgentDryRun } from "@/lib/ai/agent";
+
+const baseAiConfig = {
+  id: "ai-cfg-1", companyId: "comp-1", enabled: true,
+  whatsappEnabled: true, emailEnabled: true,
+  provider: "openai", apiKey: "encrypted-key", model: "gpt-4o",
+  temperature: 0.7, persona: "Assistente.", emailPersona: null,
+  emailSignature: null, maxIterations: 5,
+  dailySpendLimitBrl: null, escalationKeywords: [] as string[],
+};
+
+const baseTicket = {
+  id: "ticket-1", clientId: "client-1",
+  client: { id: "client-1", name: "Joao", telefone: "+5511999990000" },
+  contact: { id: "contact-1", name: "Joao", whatsapp: "+5511999990000", email: "j@t.com" },
+};
+
+function setupDefaults() {
+  mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig });
+  mockPrismaTicketFindUnique.mockResolvedValue({ ...baseTicket });
+  mockPrismaTicketMessageFindMany.mockResolvedValue([]);
+  mockDecrypt.mockReturnValue("decrypted-key");
+  mockGetTodaySpend.mockResolvedValue(0);
+  mockCheckAndReserveSpend.mockResolvedValue(true);
+  mockExecuteTool.mockResolvedValue("ok");
+  mockChatCompletion.mockResolvedValue({
+    content: "Ola!", tool_calls: undefined,
+    usage: { inputTokens: 50, outputTokens: 30 },
+  });
+}
+
+describe("runAgent", () => {
+  beforeEach(() => { vi.clearAllMocks(); setupDefaults(); });
+
+  it("error when AI not enabled", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, enabled: false });
+    const r = await runAgent("t1", "c1", "Ola");
+    expect(r).toEqual({ responded: false, escalated: false, iterations: 0, error: "AI not enabled" });
+  });
+
+  it("error when aiConfig null", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue(null);
+    expect((await runAgent("t1", "c1", "Ola")).error).toBe("AI not enabled");
+  });
+
+  it("error when WhatsApp disabled", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, whatsappEnabled: false });
+    expect((await runAgent("t1", "c1", "Ola", "WHATSAPP")).error).toBe("whatsapp_channel_disabled");
+  });
+
+  it("error when email disabled", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, emailEnabled: false });
+    expect((await runAgent("t1", "c1", "Ola", "EMAIL")).error).toBe("email_channel_disabled");
+  });
+
+  it("error when daily spend limit reached", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, dailySpendLimitBrl: 10 });
+    mockCheckAndReserveSpend.mockResolvedValue(false);
+    const r = await runAgent("t1", "c1", "Ola");
+    expect(r.error).toBe("daily_spend_limit_reached");
+  });
+
+  it("proceeds when spend below limit", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, dailySpendLimitBrl: 100 });
+    mockCheckAndReserveSpend.mockResolvedValue(true);
+    expect((await runAgent("t1", "c1", "Ola")).responded).toBe(true);
+  });
+
+  it("escalates on keyword match", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, escalationKeywords: ["cancelar"] });
+    const r = await runAgent("t1", "c1", "Quero CANCELAR");
+    expect(r.escalated).toBe(true);
+    expect(r.iterations).toBe(0);
+    expect(mockChatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("no escalation without keyword match", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, escalationKeywords: ["cancelar"] });
+    const r = await runAgent("t1", "c1", "Horario?");
+    expect(r.escalated).toBe(false);
+    expect(r.responded).toBe(true);
+  });
+
+  it("error on decrypt failure", async () => {
+    mockDecrypt.mockImplementation(() => { throw new Error("fail"); });
+    expect((await runAgent("t1", "c1", "Ola")).error).toBe("api_key_decrypt_failed");
+  });
+
+  it("uses env config when no API key", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, apiKey: null });
+    mockGetEnvProviderConfig.mockResolvedValue({ provider: "openai", apiKey: "env-k", model: "gpt-4o" });
+    expect((await runAgent("t1", "c1", "Ola")).responded).toBe(true);
+    expect(mockGetEnvProviderConfig).toHaveBeenCalled();
+  });
+
+  it("error when ticket not found", async () => {
+    mockPrismaTicketFindUnique.mockResolvedValue(null);
+    expect((await runAgent("t1", "c1", "Ola")).error).toBe("Ticket not found");
+  });
+
+  it("error when no phone for WhatsApp", async () => {
+    mockPrismaTicketFindUnique.mockResolvedValue({
+      ...baseTicket,
+      contact: { ...baseTicket.contact, whatsapp: null },
+      client: { ...baseTicket.client, telefone: null },
+    });
+    expect((await runAgent("t1", "c1", "Ola", "WHATSAPP")).error).toBe("No phone number available for reply");
+  });
+
+  it("responded=true on text response", async () => {
+    const r = await runAgent("t1", "c1", "Ola");
+    expect(r.responded).toBe(true);
+    expect(r.iterations).toBe(1);
+    expect(mockLogUsage).toHaveBeenCalled();
+  });
+
+  it("responded=true via RESPOND tool", async () => {
+    mockChatCompletion.mockResolvedValue({
+      content: null,
+      tool_calls: [{ id: "c1", type: "function", function: { name: "RESPOND", arguments: '{"message":"R"}' } }],
+      usage: { inputTokens: 50, outputTokens: 30 },
+    });
+    expect((await runAgent("t1", "c1", "Ola")).responded).toBe(true);
+    expect(mockExecuteTool).toHaveBeenCalledWith("RESPOND", { message: "R" }, expect.any(Object));
+  });
+
+  it("escalated=true via ESCALATE tool", async () => {
+    mockChatCompletion.mockResolvedValue({
+      content: null,
+      tool_calls: [{ id: "c1", type: "function", function: { name: "ESCALATE", arguments: '{"reason":"X"}' } }],
+      usage: { inputTokens: 50, outputTokens: 30 },
+    });
+    const r = await runAgent("t1", "c1", "Ajuda");
+    expect(r.escalated).toBe(true);
+    expect(r.responded).toBe(false);
+  });
+
+  it("error on empty LLM response", async () => {
+    mockChatCompletion.mockResolvedValue({ content: null, tool_calls: undefined, usage: { inputTokens: 10, outputTokens: 0 } });
+    expect((await runAgent("t1", "c1", "Ola")).error).toBe("empty LLM response");
+  });
+
+  it("error when no default model", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, provider: "unknown", model: null });
+    mockDecrypt.mockReturnValue("k");
+    expect((await runAgent("t1", "c1", "Ola")).error).toContain("no_default_model_for_provider");
+  });
+});
+
+describe("runAgentDryRun", () => {
+  beforeEach(() => { vi.clearAllMocks(); setupDefaults(); });
+
+  it("error when AI not configured", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue(null);
+    expect((await runAgentDryRun("c1", "Ola")).error).toBe("AI not configured");
+  });
+
+  it("error when AI not enabled", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, enabled: false });
+    expect((await runAgentDryRun("c1", "Ola")).error).toBe("AI not enabled");
+  });
+
+  it("error when WhatsApp disabled", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, whatsappEnabled: false });
+    expect((await runAgentDryRun("c1", "Ola", "WHATSAPP")).error).toBe("whatsapp_channel_disabled");
+  });
+
+  it("error when email disabled", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, emailEnabled: false });
+    expect((await runAgentDryRun("c1", "Ola", "EMAIL")).error).toBe("email_channel_disabled");
+  });
+
+  it("detects escalation keyword", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, escalationKeywords: ["cancelar"] });
+    const r = await runAgentDryRun("c1", "Quero cancelar");
+    expect(r.response).toContain("cancelar");
+    expect(r.estimatedCostBrl).toBe(0);
+    expect(mockChatCompletion).not.toHaveBeenCalled();
+  });
+
+  it("returns response and cost on success", async () => {
+    mockChatCompletion.mockResolvedValue({ content: "Sim!", usage: { inputTokens: 100, outputTokens: 50 } });
+    const r = await runAgentDryRun("c1", "Preco?");
+    expect(r.response).toBe("Sim!");
+    expect(r.inputTokens).toBe(100);
+    expect(r.outputTokens).toBe(50);
+    expect(r.estimatedCostBrl).toBeGreaterThan(0);
+  });
+
+  it("RESPOND tool message as response", async () => {
+    mockChatCompletion.mockResolvedValue({
+      content: null,
+      tool_calls: [{ id: "c1", type: "function", function: { name: "RESPOND", arguments: '{"message":"Ola!"}' } }],
+      usage: { inputTokens: 30, outputTokens: 20 },
+    });
+    expect((await runAgentDryRun("c1", "Oi")).response).toBe("Ola!");
+  });
+
+  it("ESCALATE in dry-run", async () => {
+    mockChatCompletion.mockResolvedValue({
+      content: null,
+      tool_calls: [{ id: "c1", type: "function", function: { name: "ESCALATE", arguments: '{"reason":"Complexo"}' } }],
+      usage: { inputTokens: 30, outputTokens: 20 },
+    });
+    const r = await runAgentDryRun("c1", "Ajuda");
+    expect(r.response).toContain("Escalado");
+  });
+
+  it("error on decrypt failure", async () => {
+    mockDecrypt.mockImplementation(() => { throw new Error("fail"); });
+    expect((await runAgentDryRun("c1", "Ola")).error).toBe("api_key_decrypt_failed");
+  });
+
+  it("uses env config when no API key", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, apiKey: null });
+    mockGetEnvProviderConfig.mockResolvedValue({ provider: "openai", apiKey: "env-k", model: "gpt-4o" });
+    mockChatCompletion.mockResolvedValue({ content: "ok", usage: { inputTokens: 10, outputTokens: 5 } });
+    expect((await runAgentDryRun("c1", "Ola")).response).toBe("ok");
+  });
+
+  it("logs with isSimulation=true", async () => {
+    mockChatCompletion.mockResolvedValue({ content: "t", usage: { inputTokens: 10, outputTokens: 5 } });
+    await runAgentDryRun("c1", "Ola");
+    expect(mockLogUsage).toHaveBeenCalledWith(expect.objectContaining({ isSimulation: true }));
+  });
+
+  it("error when no default model", async () => {
+    mockPrismaAiConfigFindUnique.mockResolvedValue({ ...baseAiConfig, provider: "unknown", model: null });
+    mockDecrypt.mockReturnValue("k");
+    expect((await runAgentDryRun("c1", "Ola")).error).toContain("no_default_model_for_provider");
+  });
+});

--- a/erp/src/lib/ai/__tests__/provider.test.ts
+++ b/erp/src/lib/ai/__tests__/provider.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Unit tests for provider.ts - AI provider abstraction layer.
+ * Fixes https://github.com/diogenesmendes01/MendesAplication/issues/230
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@/lib/ai/pricing", () => ({
+  DEFAULT_MODELS: {
+    openai: "gpt-4o",
+    anthropic: "claude-sonnet-4-20250514",
+    deepseek: "deepseek-chat",
+    grok: "grok-2",
+    qwen: "qwen-max",
+  } as Record<string, string>,
+}));
+
+import {
+  isGlobalFallbackBlocked,
+  getEnvProviderConfig,
+  chatCompletion,
+  type ProviderConfig,
+  type AiMessage,
+  type AiToolDefinition,
+} from "@/lib/ai/provider";
+
+function makeOpenAiResponse(content: string | null, toolCalls?: unknown[]) {
+  return {
+    ok: true, status: 200,
+    json: async () => ({
+      choices: [{ message: { content, tool_calls: toolCalls } }],
+      usage: { prompt_tokens: 10, completion_tokens: 20 },
+    }),
+    text: async () => "",
+  };
+}
+
+function makeAnthropicResponse(blocks: unknown[]) {
+  return {
+    ok: true, status: 200,
+    json: async () => ({ content: blocks, usage: { input_tokens: 15, output_tokens: 25 } }),
+    text: async () => "",
+  };
+}
+
+describe("isGlobalFallbackBlocked", () => {
+  const orig = process.env;
+  afterEach(() => { process.env = { ...orig }; });
+
+  it.each(["true", "1", "yes", "TRUE", " True "])('returns true for "%s"', (v) => {
+    process.env.BLOCK_GLOBAL_AI_FALLBACK = v;
+    expect(isGlobalFallbackBlocked()).toBe(true);
+  });
+
+  it.each(["false", "0", "no", ""])('returns false for "%s"', (v) => {
+    process.env.BLOCK_GLOBAL_AI_FALLBACK = v;
+    expect(isGlobalFallbackBlocked()).toBe(false);
+  });
+
+  it("returns false when unset", () => {
+    delete process.env.BLOCK_GLOBAL_AI_FALLBACK;
+    expect(isGlobalFallbackBlocked()).toBe(false);
+  });
+});
+
+describe("getEnvProviderConfig", () => {
+  const orig = process.env;
+  beforeEach(() => {
+    process.env = { ...orig };
+    delete process.env.BLOCK_GLOBAL_AI_FALLBACK;
+    delete process.env.AI_PROVIDER;
+    delete process.env.AI_API_KEY;
+    delete process.env.AI_MODEL;
+  });
+  afterEach(() => { process.env = { ...orig }; });
+
+  it("returns config from env vars", async () => {
+    process.env.AI_PROVIDER = "deepseek";
+    process.env.AI_API_KEY = "sk-test-123";
+    process.env.AI_MODEL = "deepseek-chat";
+    const c = await getEnvProviderConfig();
+    expect(c).toEqual({ provider: "deepseek", apiKey: "sk-test-123", model: "deepseek-chat" });
+  });
+
+  it("defaults provider to openai", async () => {
+    process.env.AI_API_KEY = "sk-test";
+    expect((await getEnvProviderConfig()).provider).toBe("openai");
+  });
+
+  it("throws when AI_API_KEY missing", async () => {
+    await expect(getEnvProviderConfig()).rejects.toThrow("AI_API_KEY environment variable is not set");
+  });
+
+  it("throws when fallback blocked", async () => {
+    process.env.BLOCK_GLOBAL_AI_FALLBACK = "true";
+    process.env.AI_API_KEY = "sk-test";
+    await expect(getEnvProviderConfig()).rejects.toThrow(/Global AI env fallback is blocked/);
+  });
+
+  it("omits model when AI_MODEL unset", async () => {
+    process.env.AI_API_KEY = "sk-test";
+    expect((await getEnvProviderConfig()).model).toBeUndefined();
+  });
+});
+
+describe("chatCompletion - routing", () => {
+  beforeEach(() => { mockFetch.mockReset(); });
+  const msgs: AiMessage[] = [{ role: "user", content: "Hello" }];
+
+  it("throws for unsupported provider", async () => {
+    await expect(chatCompletion(msgs, undefined, { provider: "unknown", apiKey: "k" }))
+      .rejects.toThrow("Provedor AI nao suportado: unknown");
+  });
+
+  it.each(["openai", "deepseek", "grok", "qwen"])("routes %s to OpenAI-compat", async (p) => {
+    mockFetch.mockResolvedValueOnce(makeOpenAiResponse("Hi"));
+    const r = await chatCompletion(msgs, undefined, { provider: p, apiKey: "k" });
+    expect(r.content).toBe("Hi");
+    expect(mockFetch.mock.calls[0][0]).toContain("/v1/chat/completions");
+  });
+
+  it("routes anthropic correctly", async () => {
+    mockFetch.mockResolvedValueOnce(makeAnthropicResponse([{ type: "text", text: "Bonjour" }]));
+    const r = await chatCompletion(msgs, undefined, { provider: "anthropic", apiKey: "k" });
+    expect(r.content).toBe("Bonjour");
+    expect(mockFetch.mock.calls[0][0]).toBe("https://api.anthropic.com/v1/messages");
+  });
+});
+
+describe("OpenAI-compatible completion", () => {
+  beforeEach(() => { mockFetch.mockReset(); });
+
+  it("sends correct headers and body", async () => {
+    mockFetch.mockResolvedValueOnce(makeOpenAiResponse("ok"));
+    await chatCompletion([{ role: "user", content: "test" }], undefined,
+      { provider: "openai", apiKey: "sk-abc", model: "gpt-4o", temperature: 0.5, maxTokens: 100 });
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.openai.com/v1/chat/completions");
+    expect(opts.headers.Authorization).toBe("Bearer sk-abc");
+    const body = JSON.parse(opts.body);
+    expect(body.model).toBe("gpt-4o");
+    expect(body.temperature).toBe(0.5);
+    expect(body.max_tokens).toBe(100);
+  });
+
+  it("includes tools in request", async () => {
+    mockFetch.mockResolvedValueOnce(makeOpenAiResponse("done"));
+    const tools: AiToolDefinition[] = [{ name: "SEARCH", description: "Search", parameters: { type: "object" } }];
+    await chatCompletion([{ role: "user", content: "find" }], tools, { provider: "openai", apiKey: "k" });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.tools).toHaveLength(1);
+    expect(body.tools[0].function.name).toBe("SEARCH");
+  });
+
+  it("maps tool_calls from response", async () => {
+    mockFetch.mockResolvedValueOnce(makeOpenAiResponse(null, [
+      { id: "c1", function: { name: "RESPOND", arguments: '{"message":"hi"}' } },
+    ]));
+    const r = await chatCompletion([{ role: "user", content: "x" }], [], { provider: "openai", apiKey: "k" });
+    expect(r.tool_calls).toHaveLength(1);
+    expect(r.tool_calls![0].function.name).toBe("RESPOND");
+  });
+
+  it("maps usage", async () => {
+    mockFetch.mockResolvedValueOnce(makeOpenAiResponse("ok"));
+    const r = await chatCompletion([{ role: "user", content: "t" }], undefined, { provider: "openai", apiKey: "k" });
+    expect(r.usage).toEqual({ inputTokens: 10, outputTokens: 20 });
+  });
+
+  it("throws on API error with redacted body", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401, text: async () => "bad" });
+    await expect(chatCompletion([{ role: "user", content: "t" }], undefined, { provider: "openai", apiKey: "k" }))
+      .rejects.toThrow(/openai API error 401.*redacted/);
+  });
+
+  it("throws on empty choices", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ choices: [] }), text: async () => "" });
+    await expect(chatCompletion([{ role: "user", content: "t" }], undefined, { provider: "openai", apiKey: "k" }))
+      .rejects.toThrow(/resposta vazia/);
+  });
+});
+
+describe("Anthropic completion", () => {
+  beforeEach(() => { mockFetch.mockReset(); });
+
+  it("extracts system prompt", async () => {
+    mockFetch.mockResolvedValueOnce(makeAnthropicResponse([{ type: "text", text: "r" }]));
+    await chatCompletion([{ role: "system", content: "Helpful" }, { role: "user", content: "hi" }],
+      undefined, { provider: "anthropic", apiKey: "k" });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.system).toBe("Helpful");
+    expect(body.messages.every((m: any) => m.role !== "system")).toBe(true);
+  });
+
+  it("sends anthropic-version header", async () => {
+    mockFetch.mockResolvedValueOnce(makeAnthropicResponse([{ type: "text", text: "ok" }]));
+    await chatCompletion([{ role: "user", content: "t" }], undefined, { provider: "anthropic", apiKey: "ant-k" });
+    expect(mockFetch.mock.calls[0][1].headers["anthropic-version"]).toBe("2023-06-01");
+    expect(mockFetch.mock.calls[0][1].headers["x-api-key"]).toBe("ant-k");
+  });
+
+  it("converts tool msgs to user role with tool_result", async () => {
+    mockFetch.mockResolvedValueOnce(makeAnthropicResponse([{ type: "text", text: "done" }]));
+    await chatCompletion([
+      { role: "user", content: "s" },
+      { role: "assistant", content: null, tool_calls: [{ id: "tc1", type: "function" as const, function: { name: "S", arguments: "{}" } }] },
+      { role: "tool", content: "res", tool_call_id: "tc1" },
+    ], undefined, { provider: "anthropic", apiKey: "k" });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const tm = body.messages.find((m: any) => Array.isArray(m.content) && m.content.some((c: any) => c.type === "tool_result"));
+    expect(tm).toBeDefined();
+    expect(tm.role).toBe("user");
+  });
+
+  it("parses tool_use blocks", async () => {
+    mockFetch.mockResolvedValueOnce(makeAnthropicResponse([
+      { type: "text", text: "Searching" },
+      { type: "tool_use", id: "tu1", name: "SEARCH", input: { q: "p" } },
+    ]));
+    const r = await chatCompletion([{ role: "user", content: "?" }], [], { provider: "anthropic", apiKey: "k" });
+    expect(r.content).toBe("Searching");
+    expect(r.tool_calls).toHaveLength(1);
+    expect(r.tool_calls![0].function.name).toBe("SEARCH");
+  });
+
+  it("maps usage", async () => {
+    mockFetch.mockResolvedValueOnce(makeAnthropicResponse([{ type: "text", text: "ok" }]));
+    const r = await chatCompletion([{ role: "user", content: "t" }], undefined, { provider: "anthropic", apiKey: "k" });
+    expect(r.usage).toEqual({ inputTokens: 15, outputTokens: 25 });
+  });
+
+  it("uses input_schema for tools", async () => {
+    mockFetch.mockResolvedValueOnce(makeAnthropicResponse([{ type: "text", text: "ok" }]));
+    await chatCompletion([{ role: "user", content: "t" }],
+      [{ name: "R", description: "Reply", parameters: { type: "object" } }],
+      { provider: "anthropic", apiKey: "k" });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.tools[0].input_schema).toBeDefined();
+    expect(body.tools[0].parameters).toBeUndefined();
+  });
+
+  it("merges consecutive user messages", async () => {
+    mockFetch.mockResolvedValueOnce(makeAnthropicResponse([{ type: "text", text: "ok" }]));
+    await chatCompletion([
+      { role: "user", content: "start" },
+      { role: "assistant", content: null, tool_calls: [
+        { id: "t1", type: "function" as const, function: { name: "A", arguments: "{}" } },
+        { id: "t2", type: "function" as const, function: { name: "B", arguments: "{}" } },
+      ]},
+      { role: "tool", content: "r1", tool_call_id: "t1" },
+      { role: "tool", content: "r2", tool_call_id: "t2" },
+    ], undefined, { provider: "anthropic", apiKey: "k" });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const last = body.messages[body.messages.length - 1];
+    expect(last.role).toBe("user");
+    expect(Array.isArray(last.content)).toBe(true);
+    expect(last.content).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for `provider.ts` and `agent.ts` — the two core AI modules that had no direct test coverage.

### provider.test.ts (34 tests)
- `isGlobalFallbackBlocked` env var parsing (truthy/falsy values)
- `getEnvProviderConfig` env-based config resolution and guards
- `chatCompletion` provider routing (OpenAI, Anthropic, DeepSeek, Grok, Qwen)
- OpenAI-compatible request/response mapping (headers, body, tools, usage)
- Anthropic Messages API (system prompt extraction, tool_use blocks, consecutive user message merging)
- Error handling (redacted error bodies, empty responses, unsupported providers)

### agent.test.ts (29 tests)
- `runAgent`: channel gating (WhatsApp/email disabled)
- `runAgent`: daily spend limit enforcement
- `runAgent`: escalation keyword fast-path
- `runAgent`: provider config resolution (decrypt, env fallback)
- `runAgent`: agent loop outcomes (text response, RESPOND tool, ESCALATE tool, empty response)
- `runAgentDryRun`: mirrors all guards + dry-run specific behavior
- Cost estimation and simulation usage logging

All 63 tests pass.

Fixes #230