### PR TITLE
fix: replace regex HTML sanitization with sanitize-html in email workers

### DIFF
--- a/erp/src/lib/ai/__tests__/sanitize-email-html.test.ts
+++ b/erp/src/lib/ai/__tests__/sanitize-email-html.test.ts
@@ -164,3 +164,63 @@ describe("sanitizeEmailHtml", () => {
     expect(result).toContain("<p>ok</p>");
   });
 });
+
+// ─── stripHtmlToText Tests (Issue #293) ──────────────────────────────────────
+
+import { stripHtmlToText } from "@/lib/ai/sanitize-utils";
+
+describe("stripHtmlToText", () => {
+  it("strips all HTML tags and returns plain text", () => {
+    expect(stripHtmlToText("<p>Hello <b>world</b></p>")).toBe("Hello world");
+  });
+
+  it("strips <script> tags and their content", () => {
+    const result = stripHtmlToText("<script>alert(1)</script>safe text");
+    expect(result).not.toContain("<script");
+    expect(result).toContain("safe text");
+  });
+
+  it("strips <img> tracking pixels", () => {
+    const result = stripHtmlToText('text<img src="http://evil.com/pixel.gif" />more');
+    expect(result).not.toContain("<img");
+    expect(result).not.toContain("evil.com");
+    expect(result).toContain("text");
+    expect(result).toContain("more");
+  });
+
+  it("handles malformed tags that bypass regex (e.g. attribute with >)", () => {
+    // The old regex `/<[^>]*>/g` would fail on this — it would match up to
+    // the `>` inside the attribute, leaving a broken fragment.
+    const result = stripHtmlToText('<b onclick="a>b">texto</b>');
+    expect(result).not.toContain("<b");
+    expect(result).not.toContain("onclick");
+    expect(result).toContain("texto");
+  });
+
+  it("handles unclosed tags", () => {
+    const result = stripHtmlToText("<div>content<br>more");
+    expect(result).not.toContain("<div");
+    expect(result).not.toContain("<br");
+    expect(result).toContain("content");
+    expect(result).toContain("more");
+  });
+
+  it("passes plain text through unchanged", () => {
+    expect(stripHtmlToText("just plain text")).toBe("just plain text");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripHtmlToText("")).toBe("");
+  });
+
+  it("strips nested HTML completely", () => {
+    const result = stripHtmlToText("<div><p><b>deep</b></p></div>");
+    expect(result).toBe("deep");
+  });
+
+  it("strips <style> tags", () => {
+    const result = stripHtmlToText("<style>body{color:red}</style>text");
+    expect(result).not.toContain("<style");
+    expect(result).toContain("text");
+  });
+});

--- a/erp/src/lib/ai/sanitize-utils.ts
+++ b/erp/src/lib/ai/sanitize-utils.ts
@@ -5,6 +5,9 @@
 //
 // Resolves TODO #103: replaced regex-based sanitization with `sanitize-html`
 // package for production-grade HTML sanitization.
+//
+// Resolves #293: added stripHtmlToText for inbound email text extraction,
+// replacing fragile regex `.replace(/<[^>]*>/g, "")`.
 
 import sanitizeHtml from "sanitize-html";
 
@@ -27,6 +30,16 @@ const EMAIL_SANITIZE_CONFIG: sanitizeHtml.IOptions = {
 };
 
 /**
+ * Configuration to strip ALL HTML tags, returning plain text only.
+ * Used for inbound email text extraction where no HTML should remain.
+ */
+const STRIP_ALL_CONFIG: sanitizeHtml.IOptions = {
+  allowedTags: [],
+  allowedAttributes: {},
+  disallowedTagsMode: "discard",
+};
+
+/**
  * Sanitizes LLM-generated HTML before email dispatch.
  *
  * Uses `sanitize-html` with a restrictive allow-list to prevent
@@ -36,4 +49,15 @@ const EMAIL_SANITIZE_CONFIG: sanitizeHtml.IOptions = {
  */
 export function sanitizeEmailHtml(input: string): string {
   return sanitizeHtml(input, EMAIL_SANITIZE_CONFIG);
+}
+
+/**
+ * Strips ALL HTML tags from input, returning plain text only.
+ *
+ * Replaces the fragile regex pattern `str.replace(/<[^>]*>/g, "")` which
+ * can be bypassed with malformed tags (e.g. `<b onclick="a>b">`) or
+ * unclosed tags. Uses `sanitize-html` parser for robust tag removal.
+ */
+export function stripHtmlToText(input: string): string {
+  return sanitizeHtml(input, STRIP_ALL_CONFIG);
 }

--- a/erp/src/lib/workers/email-inbound.ts
+++ b/erp/src/lib/workers/email-inbound.ts
@@ -1,3 +1,4 @@
+import { stripHtmlToText } from "@/lib/ai/sanitize-utils";
 import { Job } from "bullmq";
 import { ImapFlow } from "imapflow";
 import type { FetchMessageObject, MessageStructureObject } from "imapflow";
@@ -322,11 +323,12 @@ export async function processEmail(
     const rawStr = msg.source.toString("utf-8");
     const headerEnd = rawStr.indexOf("\r\n\r\n");
     if (headerEnd > 0) {
-      textContent = rawStr
-        .substring(headerEnd + 4)
-        .replace(/<[^>]*>/g, "") // strip HTML tags
-        .replace(/=\r?\n/g, "") // handle quoted-printable line continuations
-        .replace(/=([0-9A-F]{2})/gi, (_, hex) => String.fromCharCode(parseInt(hex, 16))) // decode QP
+      textContent = stripHtmlToText(
+        rawStr
+          .substring(headerEnd + 4)
+          .replace(/=\r?\n/g, "") // handle quoted-printable line continuations
+          .replace(/=([0-9A-F]{2})/gi, (_, hex) => String.fromCharCode(parseInt(hex, 16))) // decode QP
+      )
         .trim()
         .substring(0, 5000); // limit content length
     }

--- a/erp/src/lib/workers/email-outbound.ts
+++ b/erp/src/lib/workers/email-outbound.ts
@@ -1,3 +1,4 @@
+import { sanitizeEmailHtml } from "@/lib/ai/sanitize-utils";
 import { Job } from "bullmq";
 import nodemailer from "nodemailer";
 import { prisma } from "@/lib/prisma";
@@ -69,7 +70,7 @@ export async function processEmailOutbound(job: Job<EmailOutboundJobData>) {
       from: smtpUser,
       to,
       subject,
-      html: `<div style="font-family: Arial, sans-serif;">${content.replace(/\n/g, "<br>")}</div>`,
+      html: `<div style="font-family: Arial, sans-serif;">${sanitizeEmailHtml(content.replace(/\n/g, "<br>"))}</div>`,
       attachments,
     });
 


### PR DESCRIPTION
## Summary

Replace fragile regex-based HTML sanitization in email workers with the `sanitize-html` library (already in dependencies).

## Problem

Emails were being sanitized with `.replace(/<[^>]*>/g, "")` which is bypass-prone — malformed tags like `<b onclick="a>b">` break the regex, and unclosed tags can leak through.

## Changes

### `erp/src/lib/ai/sanitize-utils.ts`
- Added `stripHtmlToText()` — strips ALL HTML tags using `sanitize-html` with empty allowlist
- Added `STRIP_ALL_CONFIG` for zero-tag-allowed sanitization

### `erp/src/lib/workers/email-inbound.ts`
- Replaced `rawStr.replace(/<[^>]*>/g, "")` with `stripHtmlToText()` call
- QP decoding now happens before HTML stripping (correct order)

### `erp/src/lib/workers/email-outbound.ts`
- Wrapped outbound content with `sanitizeEmailHtml()` before embedding in HTML template
- Prevents XSS if `content` contains unsanitized HTML

### `erp/src/lib/ai/__tests__/sanitize-email-html.test.ts`
- Added 9 tests for `stripHtmlToText()` covering:
  - Basic tag stripping
  - Script/style removal
  - Tracking pixel stripping
  - Malformed tag bypass (the exact case regex fails on)
  - Unclosed tags, nested HTML, plain text passthrough

Fixes #293