### PR TITLE
fix: mobile sidebar overlaps content at 375px viewport

### DIFF
--- a/erp/src/components/header.tsx
+++ b/erp/src/components/header.tsx
@@ -66,7 +66,8 @@ export function Header({ sidebarCollapsed, onMenuClick }: HeaderProps) {
     <header
       className={cn(
         "fixed top-0 right-0 z-30 flex h-14 items-center border-b border-border-subtle bg-background transition-all duration-300",
-        sidebarCollapsed ? "left-16" : "left-60"
+        "left-0",
+        sidebarCollapsed ? "md:left-16" : "md:left-60"
       )}
     >
       <div className="flex w-full items-center justify-between px-4">


### PR DESCRIPTION
## Problem

At 375px viewport width, the header was offset by the sidebar width (`left-16` or `left-60`) even though the sidebar is hidden off-screen on mobile. This made the app unusable on small screens.

## Fix

Changed `header.tsx` to use `left-0` as the base positioning, and only apply the sidebar offset at the `md:` breakpoint (`md:left-16` / `md:left-60`).

The layout already had correct mobile sidebar behavior:
- Sidebar hidden via `-translate-x-full` on mobile
- Hamburger toggle in header
- Backdrop overlay when mobile sidebar is open

Only the header `left` positioning was missing the responsive prefix.

## Changes

- `erp/src/components/header.tsx`: Added `left-0` base class, prefixed sidebar offsets with `md:`

Fixes #347