### PR TITLE
fix(sac): add channel sub-navigation to sidebar

### DIFF
--- a/erp/src/components/sidebar.tsx
+++ b/erp/src/components/sidebar.tsx
@@ -22,6 +22,10 @@ import {
   Landmark,
   X,
   LogOut,
+  LayoutGrid,
+  Mail,
+  MessageCircle,
+  Star,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -52,7 +56,17 @@ interface NavItem {
 const navItems: NavItem[] = [
   { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { label: "Comercial", href: "/comercial", icon: ShoppingCart },
-  { label: "SAC", href: "/sac", icon: Headphones },
+  {
+    label: "SAC",
+    href: "/sac",
+    icon: Headphones,
+    children: [
+      { label: "Visão Geral", href: "/sac", icon: LayoutGrid },
+      { label: "Email", href: "/sac/email", icon: Mail },
+      { label: "WhatsApp", href: "/sac/whatsapp", icon: MessageCircle },
+      { label: "Reclame Aqui", href: "/sac/reclameaqui", icon: Star },
+    ],
+  },
   { label: "Financeiro", href: "/financeiro", icon: DollarSign },
   { label: "Fiscal", href: "/fiscal", icon: FileText },
   {


### PR DESCRIPTION
## O que mudou

Adiciona sub-itens do SAC no sidebar, conforme planejado:

```
SAC
 ├── Visão Geral (/sac)
 ├── Email (/sac/email)
 ├── WhatsApp (/sac/whatsapp)
 └── Reclame Aqui (/sac/reclameaqui)
```

## Por que faltou

O S2 criou as rotas mas não atualizou o `navItems` do sidebar com os children do SAC.

## Mudanças
- `sidebar.tsx`: SAC agora tem `children` com 4 itens (LayoutGrid, Mail, MessageCircle, Star icons)
- Badge de SLA permanece no item pai
- Comportamento de expand/collapse igual ao Configurações (já existente)