### PR TITLE
fix(sac): correct RECLAMEAQUI enum in ticket cards (RA v2 S1)

### DIFF
--- a/erp/src/app/(app)/sac/components/ticket-card.tsx
+++ b/erp/src/app/(app)/sac/components/ticket-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Mail, MessageSquare, Globe, AlertTriangle, Bot, DollarSign, Clock } from "lucide-react";
+import { Mail, MessageSquare, Globe, Star, AlertTriangle, Bot, DollarSign, Clock } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import type { TicketRow } from "../tickets/actions";
 
@@ -41,13 +41,14 @@ function getInitials(name: string): string {
 function ChannelIcon({ type }: { type: string | null }) {
   if (type === "EMAIL") return <Mail className="h-3 w-3" />;
   if (type === "WHATSAPP") return <MessageSquare className="h-3 w-3" />;
+  if (type === "RECLAMEAQUI") return <Star className="h-3 w-3" />;
   return <Globe className="h-3 w-3" />;
 }
 
 function channelLabel(type: string | null): string {
   if (type === "EMAIL") return "Email";
   if (type === "WHATSAPP") return "WhatsApp";
-  if (type === "RECLAME_AQUI") return "RA";
+  if (type === "RECLAMEAQUI") return "Reclame Aqui";
   return "Web";
 }
 


### PR DESCRIPTION
## Problema
Cards de tickets Reclame Aqui mostram 'Web' ao invés de 'Reclame Aqui' por causa de RECLAME_AQUI (underscore) vs RECLAMEAQUI (enum Prisma).

## Fix
- Corrige channelLabel() e ChannelIcon() em ticket-card.tsx
- Busca e corrige qualquer outra referência com underscore