### PR TITLE
feat(sac): complete HugMe error codes (RA v2 S2)

### DIFF
--- a/erp/src/app/(app)/sac/tickets/ra-actions.ts
+++ b/erp/src/app/(app)/sac/tickets/ra-actions.ts
@@ -7,6 +7,7 @@ import { reclameaquiOutboundQueue } from "@/lib/queue";
 import { ReclameAquiClient, ReclameAquiError } from "@/lib/reclameaqui/client";
 import { RaModerationReason } from "@/lib/reclameaqui/types";
 import type { RaReputation, RaClientConfig } from "@/lib/reclameaqui/types";
+import { RA_ERROR_MESSAGES } from "@/lib/reclameaqui/errors";
 import { Prisma } from "@prisma/client";
 import { logger } from "@/lib/logger";
 
@@ -41,21 +42,6 @@ export interface RaReputationResult extends RaActionResult {
 // Error Mapping
 // ---------------------------------------------------------------------------
 
-const RA_ERROR_MESSAGES: Record<number, string> = {
-  4000: "Requisição inválida para o Reclame Aqui",
-  4010: "Autenticação com Reclame Aqui falhou — verifique as credenciais",
-  4030: "Sem permissão para esta ação no Reclame Aqui",
-  4040: "Ticket não encontrado no Reclame Aqui",
-  4050: "Ação não permitida pela API do Reclame Aqui",
-  4090: "Ticket inativo",
-  4091: "Ticket não permite esta ação no momento",
-  4095: "Ticket já foi avaliado",
-  4220: "Dados inválidos — verifique os campos enviados",
-  4290: "Limite de requisições excedido — tente novamente em alguns minutos",
-  5000: "Erro interno do Reclame Aqui — tente novamente",
-  5030: "Reclame Aqui temporariamente indisponível",
-  40930: "Mensagem duplicada — já foi enviada",
-};
 
 function mapRaError(err: unknown): string {
   if (err instanceof ReclameAquiError) {

--- a/erp/src/lib/reclameaqui/client.ts
+++ b/erp/src/lib/reclameaqui/client.ts
@@ -5,6 +5,7 @@
 // Uses native fetch — no axios.
 
 import { logger } from "@/lib/logger";
+import { RA_ERROR_MESSAGES } from "./errors";
 import type {
   RaClientConfig,
   RaAuthResponse,
@@ -23,28 +24,13 @@ import type {
 // Error Handling
 // ──────────────────────────────────────────────
 
-/** Map of known API error codes → user-friendly descriptions */
-const ERROR_CODE_MAP: Record<number, string> = {
-  4000: "Requisição inválida",
-  4010: "Token inválido ou expirado",
-  4030: "Acesso negado — verifique permissões",
-  4040: "Recurso não encontrado",
-  4050: "Método não permitido",
-  4090: "Conflito — ação já realizada ou duplicada",
-  4091: "Conflito de estado — ticket não permite esta ação",
-  4220: "Dados inválidos — verifique os campos enviados",
-  4290: "Rate limit excedido — aguarde antes de tentar novamente",
-  5000: "Erro interno do servidor Reclame Aqui",
-  5030: "Serviço temporariamente indisponível",
-};
-
 export class ReclameAquiError extends Error {
   public readonly code: number;
   public readonly httpStatus: number;
   public readonly originalMessage: string;
 
   constructor(message: string, code: number, httpStatus: number, originalMessage: string) {
-    const friendly = ERROR_CODE_MAP[code];
+    const friendly = RA_ERROR_MESSAGES[code];
     super(friendly ? `${friendly}: ${message}` : message);
     this.name = "ReclameAquiError";
     this.code = code;

--- a/erp/src/lib/reclameaqui/errors.ts
+++ b/erp/src/lib/reclameaqui/errors.ts
@@ -1,0 +1,52 @@
+/**
+ * Complete HugMe/Reclame Aqui API error code mapping.
+ *
+ * Single source of truth — imported by client.ts and ra-actions.ts.
+ * Codes sourced from official HugMe API documentation.
+ */
+export const RA_ERROR_MESSAGES: Record<number, string> = {
+  // ── HTTP-level ──────────────────────────────────────────────────────
+  4000: "Requisição inválida",
+  4010: "Token inválido ou expirado",
+  4030: "Acesso negado — verifique permissões",
+  4040: "Recurso não encontrado",
+  4050: "Método não permitido",
+
+  // ── Ticket / Avaliação ──────────────────────────────────────────────
+  4090: "Ticket inativo",
+  4091: "Ticket não é do Reclame Aqui — avaliação indisponível",
+  4092: "Ticket com moderação pendente — avaliação bloqueada",
+  4093: "Ticket não foi respondido — responda antes de solicitar avaliação",
+  4094: "Ticket sem resposta pública da empresa",
+  4095: "Ticket já foi avaliado",
+  4096: "Reclamação não elegível para avaliação no Reclame Aqui",
+  4097: "Erro ao criar histórico de ação",
+  4098: "Limite de anexos excedido (máx 6 arquivos)",
+  4099: "Limite diário de moderações excedido",
+
+  // ── Validação / Rate-limit ──────────────────────────────────────────
+  4220: "Dados inválidos — verifique os campos",
+  4290: "Limite de requisições excedido — aguarde 1 minuto",
+
+  // ── Server ──────────────────────────────────────────────────────────
+  5000: "Erro interno do servidor Reclame Aqui",
+  5030: "Serviço temporariamente indisponível",
+
+  // ── Moderação (409xx) ───────────────────────────────────────────────
+  40910: "Limite de moderações por reclamação excedido",
+  40912: "Moderação por duplicidade impossível — última resposta é da empresa",
+  40913: "Moderação requer resposta pública + avaliação do consumidor",
+  40914: "Motivo de moderação não permitido",
+  40915: "Ticket não é do Reclame Aqui",
+  40916: "Ticket já tem moderação pendente",
+  40917: "Moderação já foi solicitada para este ticket",
+  40918: "Erro inesperado na moderação",
+
+  // ── Mensagens / Interações (409xx) ──────────────────────────────────
+  40919: "Fonte do ticket não suporta mensagens privadas",
+  40920: "Ticket fechado com última resposta da empresa — mensagem pública bloqueada",
+  40921: "Erro ao criar interação no ticket",
+  40922: "Tipo de anexo não suportado (aceitos: png, jpg, gif, pdf, doc, xls, csv, mp3, wma, ogg, aac)",
+  40925: "Mensagem privada já encerrada ou não iniciada",
+  40930: "Mensagem duplicada — já enviada recentemente",
+};


### PR DESCRIPTION
## O que mudou
Mapeia todos os 30+ error codes da API HugMe com mensagens em pt-BR acionáveis.

## Por que
Usuários e agentes IA viam 'Erro inesperado' para situações documentadas (moderação bloqueada, avaliação já feita, etc).

## Mudanças
- Novo: `src/lib/reclameaqui/errors.ts` (single source of truth)
- Atualiza `client.ts` e `ra-actions.ts` para importar do novo arquivo
- De ~11 códigos para 33 códigos mapeados