### PR TITLE
feat(sac): RA API availability check before sync (RA v2 S7)

### DIFF
--- a/erp/src/lib/reclameaqui/client.ts
+++ b/erp/src/lib/reclameaqui/client.ts
@@ -283,6 +283,19 @@ export class ReclameAquiClient {
   }
 
   /**
+   * Check Reading API (ticket) availability.
+   * Returns true if available, false otherwise.
+   */
+  async checkTicketAvailability(): Promise<boolean> {
+    try {
+      const result = await this.request<{ message: string }>("GET", "/ticket/availability", { skipAuth: true });
+      return result?.message === "Ticket API";
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Retrieve tickets with optional filters.
    */
   async getTickets(

--- a/erp/src/lib/workers/reclameaqui-inbound.ts
+++ b/erp/src/lib/workers/reclameaqui-inbound.ts
@@ -378,6 +378,13 @@ export async function processReclameAquiInbound(_job: Job): Promise<void> {
       baseUrl: config.baseUrl,
     });
 
+    // Check ticket API availability before sync
+    const isAvailable = await client.checkTicketAvailability();
+    if (!isAvailable) {
+      logger.warn(`[reclameaqui-inbound] Ticket API indisponível, sync skipado para channel ${ch.id}`);
+      continue;
+    }
+
     const lastSyncDate = config.lastSyncDate || defaultSyncDate();
 
     try {


### PR DESCRIPTION
## O que mudou
- Adiciona checkTicketAvailability() no ReclameAquiClient
- Verifica disponibilidade da Reading API antes de cada sync
- Se indisponível, skip gracioso com log warning (sem retry)

## Por que
Evita erros desnecessários quando a API HugMe está fora do ar