### PR TITLE
feat(sac): enriched RA context for AI suggestions (RA v2 S8)

### DIFF
--- a/erp/src/lib/ai/agent.ts
+++ b/erp/src/lib/ai/agent.ts
@@ -373,7 +373,7 @@ export async function runAgent(
   companyId: string,
   incomingMessage: string,
   channel: "WHATSAPP" | "EMAIL" | "RECLAMEAQUI" = "WHATSAPP",
-  options?: { suggestionMode?: boolean },
+  options?: { suggestionMode?: boolean; raContext?: import("@/lib/reclameaqui/types").RaAiContext },
 ): Promise<AgentResult> {
   const startTime = Date.now();
   const timeout = parseInt(process.env.AI_TIMEOUT || "30000", 10);
@@ -541,7 +541,7 @@ export async function runAgent(
   // Build channel-specific system prompt
   let systemPrompt: string;
   if (channel === "RECLAMEAQUI") {
-    systemPrompt = buildReclameAquiSystemPrompt(persona, clientName, historyContext);
+    systemPrompt = buildReclameAquiSystemPrompt(persona, clientName, historyContext, options?.raContext);
   } else if (channel === "EMAIL") {
     systemPrompt = buildEmailSystemPrompt(persona, clientName, historyContext, aiConfig.emailSignature);
   } else {
@@ -932,7 +932,8 @@ ${CNPJ_INSTRUCTIONS}${ATTACHMENT_INSTRUCTIONS}
 function buildReclameAquiSystemPrompt(
   persona: string,
   clientName: string,
-  historyContext: string
+  historyContext: string,
+  raContext?: import("@/lib/reclameaqui/types").RaAiContext,
 ): string {
   let prompt = `# Assistente de Atendimento - MendesERP (Reclame Aqui)
 
@@ -977,6 +978,47 @@ ${CNPJ_INSTRUCTIONS}${ATTACHMENT_INSTRUCTIONS}
 ## CONTEXTO ATUAL:
 - Canal: Reclame Aqui
 - Reclamante: ${clientName}`;
+
+  // Enrich prompt with RA ticket context when available
+  if (raContext) {
+    prompt += `\n\n## CONTEXTO ENRIQUECIDO DO TICKET RA:`;
+    if (raContext.complaintTitle) {
+      prompt += `\n- Título da reclamação: ${raContext.complaintTitle}`;
+    }
+    if (raContext.reason) {
+      prompt += `\n- Motivo/Categoria RA: ${raContext.reason}`;
+    }
+    if (raContext.feeling) {
+      prompt += `\n- Sentimento do consumidor: ${raContext.feeling}`;
+    }
+    if (raContext.categories.length > 0) {
+      prompt += `\n- Categorias: ${raContext.categories.join(", ")}`;
+    }
+    if (raContext.rating) {
+      prompt += `\n- Avaliação: ${raContext.rating}`;
+    }
+    if (raContext.resolvedIssue !== null) {
+      prompt += `\n- Problema resolvido: ${raContext.resolvedIssue ? "Sim" : "Não"}`;
+    }
+    if (raContext.interactionsCount > 0) {
+      prompt += `\n- Número de interações: ${raContext.interactionsCount}`;
+    }
+    if (raContext.previousResponseContent) {
+      prompt += `\n- Resposta anterior da empresa: ${raContext.previousResponseContent.substring(0, 500)}`;
+    }
+
+    // Contextual instructions
+    prompt += `\n\n## INSTRUÇÕES BASEADAS NO CONTEXTO:`;
+    if (raContext.feeling && ["negativo", "muito negativo", "insatisfeito", "frustrado", "raiva"].some(f => raContext.feeling!.toLowerCase().includes(f))) {
+      prompt += `\n- ⚠️ O consumidor está com sentimento NEGATIVO. Use tom mais empático e acolhedor. Reconheça a frustração antes de propor soluções.`;
+    }
+    if (raContext.isReplica) {
+      prompt += `\n- ⚠️ Esta é uma RÉPLICA do consumidor (ele respondeu após a primeira resposta da empresa). Reconheça que é uma continuação, não repita o que já foi dito e aborde diretamente o novo ponto levantado.`;
+    }
+    if (raContext.previousResponseContent) {
+      prompt += `\n- ⚠️ Já existe uma resposta anterior da empresa. NÃO repita o conteúdo. Avance na resolução ou aborde novos pontos.`;
+    }
+  }
 
   if (historyContext) {
     prompt += `\n\n## HISTÓRICO DA RECLAMAÇÃO:\n${historyContext}`;

--- a/erp/src/lib/reclameaqui/types.ts
+++ b/erp/src/lib/reclameaqui/types.ts
@@ -404,3 +404,20 @@ export interface RaAttachmentResponse {
   url: string;
   [key: string]: unknown;
 }
+
+// ──────────────────────────────────────────────
+// AI Context (enriched payload for ai-agent)
+// ──────────────────────────────────────────────
+
+export interface RaAiContext {
+  reason: string | null;
+  feeling: string | null;
+  categories: string[];
+  customerName: string | null;
+  complaintTitle: string | null;
+  previousResponseContent: string | null;
+  resolvedIssue: boolean | null;
+  rating: string | null;
+  interactionsCount: number;
+  isReplica: boolean;
+}

--- a/erp/src/lib/workers/ai-agent.ts
+++ b/erp/src/lib/workers/ai-agent.ts
@@ -24,6 +24,8 @@ interface AiAgentJobData {
   messageContent: string;
   messageId?: string; // Inbound TicketMessage id that triggered the agent
   channel?: "WHATSAPP" | "EMAIL" | "RECLAMEAQUI";
+  /** Enriched RA ticket context for better AI suggestions */
+  raContext?: import("@/lib/reclameaqui/types").RaAiContext;
 }
 
 // ---------------------------------------------------------------------------
@@ -69,7 +71,7 @@ function computeConfidenceFromResult(result: AgentResult): number {
 // ---------------------------------------------------------------------------
 
 export async function processAiAgent(job: Job<AiAgentJobData>) {
-  const { ticketId, companyId, messageContent, messageId, channel = "WHATSAPP" } = job.data;
+  const { ticketId, companyId, messageContent, messageId, channel = "WHATSAPP", raContext } = job.data;
 
   // 1. Check ticket-level AI toggle before hitting the LLM.
   //    Note: company-level AI config (enabled, channel, spend limit, escalation
@@ -166,6 +168,7 @@ export async function processAiAgent(job: Job<AiAgentJobData>) {
 
     const result = await runAgent(ticketId, companyId, messageContent, "RECLAMEAQUI", {
       suggestionMode: useSuggestionMode,
+      raContext,
     });
 
     logger.info(

--- a/erp/src/lib/workers/reclameaqui-inbound.ts
+++ b/erp/src/lib/workers/reclameaqui-inbound.ts
@@ -356,6 +356,18 @@ async function updateExistingTicket(
         companyId,
         messageContent: interaction.message,
         channel: "RECLAMEAQUI" as const,
+        raContext: {
+          reason: raTicket.ra_reason ?? null,
+          feeling: raTicket.ra_feeling ?? null,
+          categories: raTicket.categories?.map((c: any) => c.description) ?? [],
+          customerName: raTicket.customer?.name ?? null,
+          complaintTitle: raTicket.complaint_title ?? null,
+          previousResponseContent: raTicket.complaint_response_content ?? null,
+          resolvedIssue: raTicket.resolved_issue ?? null,
+          rating: raTicket.rating ?? null,
+          interactionsCount: raTicket.interactions?.length ?? 0,
+          isReplica: [7, 20].includes(raTicket.ra_status?.id ?? 0),
+        },
       });
       logger.info(
         `[reclameaqui-inbound] Enqueued ai-agent job for ticket ${existingTicket.id}`


### PR DESCRIPTION
## O que mudou
- Inbound worker passa raContext (motivo, sentimento, categorias, histórico) ao ai-agent
- Nova interface RaAiContext tipando o payload
- Worker de IA usa contexto para gerar sugestões mais precisas
- Tudo backward-compatible (raContext opcional)

## Campos do raContext
reason, feeling, categories, customerName, complaintTitle, previousResponseContent, resolvedIssue, rating, interactionsCount, isReplica

## Arquivos alterados
- `erp/src/lib/reclameaqui/types.ts` — nova interface `RaAiContext`
- `erp/src/lib/workers/reclameaqui-inbound.ts` — enriquece payload do ai-agent com raContext
- `erp/src/lib/workers/ai-agent.ts` — propaga raContext para runAgent
- `erp/src/lib/ai/agent.ts` — consome raContext no prompt do RA (instruções contextuais)