### PR TITLE
feat(sac): inbound attachment sync from RA API (RA v2 S10)

### DIFF
--- a/erp/prisma/migrations/20260327210000_add_attachment_external_fields/migration.sql
+++ b/erp/prisma/migrations/20260327210000_add_attachment_external_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable: make storagePath optional, add externalId and externalUrl
+ALTER TABLE "attachments" ALTER COLUMN "storagePath" DROP NOT NULL;
+ALTER TABLE "attachments" ADD COLUMN "externalId" TEXT;
+ALTER TABLE "attachments" ADD COLUMN "externalUrl" TEXT;

--- a/erp/prisma/schema.prisma
+++ b/erp/prisma/schema.prisma
@@ -563,8 +563,10 @@ model Attachment {
   fileName        String
   fileSize        Int
   mimeType        String
-  storagePath     String
+  storagePath     String?
   createdAt       DateTime       @default(now())
+  externalId      String?
+  externalUrl     String?
 
   ticketMessage TicketMessage? @relation("TicketMessageAttachments", fields: [ticketMessageId], references: [id], onDelete: Cascade)
   extraction    AttachmentExtraction?

--- a/erp/src/app/(app)/sac/tickets/[id]/ticket-timeline.tsx
+++ b/erp/src/app/(app)/sac/tickets/[id]/ticket-timeline.tsx
@@ -75,6 +75,68 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+
+function isImageMime(mimeType: string): boolean {
+  return mimeType.startsWith("image/");
+}
+
+/** Renders attachments with inline image thumbnails for images, download links for others */
+function AttachmentList({ attachments }: { attachments: TimelineEvent["attachments"] }) {
+  if (attachments.length === 0) return null;
+
+  const images = attachments.filter((a) => isImageMime(a.mimeType));
+  const files = attachments.filter((a) => !isImageMime(a.mimeType));
+
+  return (
+    <div className="mt-2 space-y-2">
+      {images.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {images.map((att) => (
+            <a
+              key={att.id}
+              href={att.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group relative block max-w-[200px] rounded-md overflow-hidden border hover:border-primary transition-colors"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={att.url}
+                alt={att.fileName}
+                className="max-h-[150px] w-auto object-cover"
+                loading="lazy"
+              />
+              <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors flex items-center justify-center">
+                <Download className="h-5 w-5 text-white opacity-0 group-hover:opacity-100 transition-opacity" />
+              </div>
+              <span className="block px-1.5 py-0.5 text-[10px] text-muted-foreground truncate">
+                {att.fileName}
+              </span>
+            </a>
+          ))}
+        </div>
+      )}
+      {files.map((att) => (
+        <a
+          key={att.id}
+          href={att.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 text-xs text-primary hover:underline"
+        >
+          <Paperclip className="h-3 w-3" />
+          <span>{att.fileName}</span>
+          {att.fileSize > 0 && (
+            <span className="text-muted-foreground">
+              ({formatFileSize(att.fileSize)})
+            </span>
+          )}
+          <Download className="h-3 w-3" />
+        </a>
+      ))}
+    </div>
+  );
+}
 function originLabel(event: TimelineEvent): string | null {
   if (event.type === "status_change" || event.type === "refund") return null;
   if (event.origin === "SYSTEM") return "via ERP";
@@ -248,19 +310,7 @@ function TimelineItem({ event, channelType, companyId, onActionComplete, isGroup
           <p className="text-sm whitespace-pre-wrap leading-relaxed">
             {event.content}
           </p>
-          {event.attachments.length > 0 && (
-            <div className="mt-2 space-y-1">
-              {event.attachments.map((att) => (
-                <a key={att.id} href={att.url} target="_blank" rel="noopener noreferrer"
-                  className="flex items-center gap-2 text-xs text-primary hover:underline">
-                  <Paperclip className="h-3 w-3" />
-                  <span>{att.fileName}</span>
-                  <span className="text-muted-foreground">({formatFileSize(att.fileSize)})</span>
-                  <Download className="h-3 w-3" />
-                </a>
-              ))}
-            </div>
-          )}
+          <AttachmentList attachments={event.attachments} />
         </div>
       </div>
     );
@@ -362,26 +412,7 @@ function TimelineItem({ event, channelType, companyId, onActionComplete, isGroup
         )}
 
         {/* Attachments */}
-        {event.attachments.length > 0 && (
-          <div className="mt-2 space-y-1">
-            {event.attachments.map((att) => (
-              <a
-                key={att.id}
-                href={att.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-2 text-xs text-primary hover:underline"
-              >
-                <Paperclip className="h-3 w-3" />
-                <span>{att.fileName}</span>
-                <span className="text-muted-foreground">
-                  ({formatFileSize(att.fileSize)})
-                </span>
-                <Download className="h-3 w-3" />
-              </a>
-            ))}
-          </div>
-        )}
+        <AttachmentList attachments={event.attachments} />
       </div>
     </div>
   );
@@ -452,24 +483,9 @@ function EmailThreadItem({ event, ticketSubject }: EmailThreadItemProps) {
 
       {/* Attachments */}
       {event.attachments.length > 0 && (
-        <div className="mt-3 border-t pt-3 space-y-1">
+        <div className="mt-3 border-t pt-3">
           <span className="text-xs font-medium text-muted-foreground">Anexos:</span>
-          {event.attachments.map((att) => (
-            <a
-              key={att.id}
-              href={att.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 text-xs text-primary hover:underline"
-            >
-              <Paperclip className="h-3 w-3" />
-              <span>{att.fileName}</span>
-              <span className="text-muted-foreground">
-                ({formatFileSize(att.fileSize)})
-              </span>
-              <Download className="h-3 w-3" />
-            </a>
-          ))}
+          <AttachmentList attachments={event.attachments} />
         </div>
       )}
     </div>
@@ -528,25 +544,7 @@ function WhatsAppBubble({ event }: { event: TimelineEvent }) {
         </p>
 
         {/* Attachments */}
-        {event.attachments.length > 0 && (
-          <div className="mt-1.5 space-y-1">
-            {event.attachments.map((att) => (
-              <a
-                key={att.id}
-                href={att.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-1.5 text-xs text-primary hover:underline"
-              >
-                <Paperclip className="h-3 w-3" />
-                <span>{att.fileName}</span>
-                <span className="text-muted-foreground">
-                  ({formatFileSize(att.fileSize)})
-                </span>
-              </a>
-            ))}
-          </div>
-        )}
+        <AttachmentList attachments={event.attachments} />
 
         {/* Timestamp + delivery status */}
         <div className="flex justify-end items-center gap-1 mt-1">

--- a/erp/src/app/(app)/sac/tickets/actions.ts
+++ b/erp/src/app/(app)/sac/tickets/actions.ts
@@ -832,6 +832,7 @@ export async function listTimelineEvents(
             fileSize: true,
             mimeType: true,
             storagePath: true,
+            externalUrl: true,
           },
         },
       },
@@ -881,7 +882,7 @@ export async function listTimelineEvents(
         fileName: a.fileName,
         fileSize: a.fileSize,
         mimeType: a.mimeType,
-        url: `/api/files/${a.storagePath}`,
+        url: a.externalUrl || (a.storagePath ? `/api/files/${a.storagePath}` : ''),
       })),
       refundAmount: null,
       refundStatus: null,
@@ -1237,7 +1238,7 @@ export async function attachFileToTicket(
     fileName: attachment.fileName,
     fileSize: attachment.fileSize,
     mimeType: attachment.mimeType,
-    url: `/api/files/${attachment.storagePath}`,
+    url: attachment.storagePath ? `/api/files/${attachment.storagePath}` : '',
   };
 }
 
@@ -1931,7 +1932,7 @@ export async function requestRefund(
         fileName: proofAttachment.fileName,
         fileSize: proofAttachment.fileSize,
         mimeType: proofAttachment.mimeType,
-        storagePath: proofAttachment.storagePath,
+        storagePath: proofAttachment.storagePath!,
         uploadedById: session.userId,
       },
     });
@@ -2386,7 +2387,7 @@ export async function executeRefund(
             fileName: proofFile.fileName,
             fileSize: proofFile.fileSize,
             mimeType: proofFile.mimeType,
-            storagePath: proofFile.storagePath,
+            storagePath: proofFile.storagePath!,
             uploadedById: session.userId,
           },
         });

--- a/erp/src/lib/reclameaqui/types.ts
+++ b/erp/src/lib/reclameaqui/types.ts
@@ -266,6 +266,13 @@ export const MODERATION_REASON_LABELS: Record<RaModerationReason, string> = {
 };
 
 // ──────────────────────────────────────────────
+
+export interface RaAttachment {
+  id: string;
+  type_detail_id: number;
+  name: string;
+  detail_description: string; // URL do anexo
+}
 // Ticket
 // ──────────────────────────────────────────────
 
@@ -305,6 +312,7 @@ export interface RaTicket {
   whatsapp: { sent: boolean; evaluated: boolean } | null;
   active: boolean;
   frozen: boolean;
+  attached?: RaAttachment[];
 }
 
 // ──────────────────────────────────────────────

--- a/erp/src/lib/workers/email-outbound.ts
+++ b/erp/src/lib/workers/email-outbound.ts
@@ -58,10 +58,17 @@ export async function processEmailOutbound(job: Job<EmailOutboundJobData>) {
       where: { id: { in: attachmentIds } },
     });
     for (const att of attachmentRecords) {
-      attachments.push({
-        filename: att.fileName,
-        path: path.join(process.cwd(), "uploads", att.storagePath),
-      });
+      if (att.storagePath) {
+        attachments.push({
+          filename: att.fileName,
+          path: path.join(process.cwd(), "uploads", att.storagePath),
+        });
+      } else if (att.externalUrl) {
+        attachments.push({
+          filename: att.fileName,
+          path: att.externalUrl,
+        });
+      }
     }
   }
 

--- a/erp/src/lib/workers/reclameaqui-inbound.ts
+++ b/erp/src/lib/workers/reclameaqui-inbound.ts
@@ -9,6 +9,7 @@ import type {
   RaClientConfig,
   RaTicket,
   RaInteraction,
+  RaInteractionDetail,
 } from "@/lib/reclameaqui/types";
 import {
   RA_INTERACTION_TYPES,
@@ -128,6 +129,145 @@ function buildMessageContent(interaction: RaInteraction): string {
   return content;
 }
 
+/**
+ * Guess MIME type from file name extension.
+ */
+function guessMimeType(fileName: string): string {
+  const ext = fileName.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "png":
+      return "image/png";
+    case "gif":
+      return "image/gif";
+    case "webp":
+      return "image/webp";
+    case "pdf":
+      return "application/pdf";
+    case "doc":
+      return "application/msword";
+    case "docx":
+      return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    case "xls":
+      return "application/vnd.ms-excel";
+    case "xlsx":
+      return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    case "mp4":
+      return "video/mp4";
+    case "mp3":
+      return "audio/mpeg";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Attachment Processing
+// ---------------------------------------------------------------------------
+
+/**
+ * Sync ticket-level attachments from RA `attached[]` array.
+ * Deduplicates by externalId to avoid duplicates on re-syncs.
+ */
+async function syncTicketAttachments(
+  tx: TxClient,
+  ticketId: string,
+  raTicket: RaTicket
+): Promise<void> {
+  if (!raTicket.attached?.length) return;
+
+  for (const att of raTicket.attached) {
+    const extId = att.id?.toString();
+    if (!extId) continue;
+
+    // Deduplicate by externalId
+    const existing = await tx.attachment.findFirst({
+      where: { ticketId, externalId: extId },
+      select: { id: true },
+    });
+
+    if (existing) continue;
+
+    const fileName = att.name || `attachment-${att.id}`;
+    await tx.attachment.create({
+      data: {
+        ticketId,
+        fileName,
+        fileSize: 0, // RA doesn't return file size
+        mimeType: guessMimeType(fileName),
+        storagePath: null, // External attachment — no local storage
+        externalId: extId,
+        externalUrl: att.detail_description || "",
+      },
+    });
+  }
+}
+
+/**
+ * Sync interaction-level attachments (detail_type 15 = ANEXO, 33 = ANEXO_2)
+ * as Attachments linked to the TicketMessage.
+ */
+async function syncInteractionAttachments(
+  tx: TxClient,
+  ticketId: string,
+  messageId: string,
+  details: RaInteractionDetail[],
+  raClient?: ReclameAquiClient
+): Promise<void> {
+  if (!details?.length) return;
+
+  const attachmentDetails = details.filter(
+    (d) =>
+      d.ticket_detail_type_id === RA_DETAIL_TYPES.ANEXO ||
+      d.ticket_detail_type_id === RA_DETAIL_TYPES.ANEXO_2
+  );
+
+  for (const detail of attachmentDetails) {
+    const extId = detail.ticket_detail_id?.toString();
+    if (!extId) continue;
+
+    // Deduplicate by externalId
+    const existing = await tx.attachment.findFirst({
+      where: { ticketMessageId: messageId, externalId: extId },
+      select: { id: true },
+    });
+
+    if (existing) continue;
+
+    let url = detail.value || detail.name || "";
+
+    // Fallback: if URL is empty, try fetching via API
+    if (!url && raClient) {
+      try {
+        const linkResult = await raClient.getAttachmentLink(extId);
+        url = linkResult?.url || "";
+      } catch {
+        logger.warn(
+          `[reclameaqui-inbound] Failed to fetch attachment link for detail ${extId}`
+        );
+      }
+    }
+
+    if (!url) continue;
+
+    const fileName = detail.name || `attachment-${extId}`;
+    await tx.attachment.create({
+      data: {
+        ticketMessageId: messageId,
+        ticketId,
+        fileName,
+        fileSize: 0,
+        mimeType: guessMimeType(fileName),
+        storagePath: null,
+        externalId: extId,
+        externalUrl: url,
+      },
+    });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Ticket Processing
 // ---------------------------------------------------------------------------
@@ -136,7 +276,8 @@ async function processRaTicket(
   raTicket: RaTicket,
   companyId: string,
   channelId: string,
-  summary: SyncSummary
+  summary: SyncSummary,
+  raClient?: ReclameAquiClient
 ): Promise<void> {
   const externalId = raTicket.source_external_id;
   const raStatusId = raTicket.ra_status.id;
@@ -157,10 +298,10 @@ async function processRaTicket(
   });
 
   if (!existingTicket) {
-    await createNewTicket(raTicket, companyId, channelId, ticketStatus, raStatusId, raStatusName);
+    await createNewTicket(raTicket, companyId, channelId, ticketStatus, raStatusId, raStatusName, raClient);
     summary.created++;
   } else {
-    await updateExistingTicket(existingTicket, raTicket, companyId, ticketStatus, raStatusId, raStatusName);
+    await updateExistingTicket(existingTicket, raTicket, companyId, ticketStatus, raStatusId, raStatusName, raClient);
     summary.updated++;
   }
 }
@@ -171,7 +312,8 @@ async function createNewTicket(
   channelId: string,
   ticketStatus: TicketStatus,
   raStatusId: number,
-  raStatusName: string
+  raStatusName: string,
+  raClient?: ReclameAquiClient
 ): Promise<void> {
   const customer = raTicket.customer;
   const customerEmail = customer.email?.[0]?.trim().toLowerCase();
@@ -264,9 +406,12 @@ async function createNewTicket(
       },
     });
 
-    // Create messages from interactions
+    // Sync ticket-level attachments (attached[])
+    await syncTicketAttachments(tx, ticket.id, raTicket);
+
+    // Create messages from interactions (+ their attachments)
     for (const interaction of raTicket.interactions) {
-      await createTicketMessage(tx, ticket.id, interaction);
+      await createTicketMessage(tx, ticket.id, interaction, raClient);
     }
 
     logger.info(
@@ -285,7 +430,8 @@ async function updateExistingTicket(
   companyId: string,
   ticketStatus: TicketStatus,
   raStatusId: number,
-  raStatusName: string
+  raStatusName: string,
+  raClient?: ReclameAquiClient
 ): Promise<void> {
   const existingMessageIds = new Set(
     existingTicket.messages
@@ -297,40 +443,45 @@ async function updateExistingTicket(
     (i) => !existingMessageIds.has(i.ticket_interaction_id)
   );
 
-  // Update ticket RA fields
-  await prisma.ticket.update({
-    where: { id: existingTicket.id },
-    data: {
-      status: ticketStatus,
-      raStatusId,
-      raStatusName,
-      raCanEvaluate: raTicket.request_evaluation ?? false,
-      raCanModerate: raTicket.request_moderation ?? false,
-      raRating: raTicket.rating,
-      raResolvedIssue: raTicket.resolved_issue,
-      raBackDoingBusiness: raTicket.back_doing_business,
-      raFrozen: raStatusId === 10,
-      raReason: raTicket.ra_reason ?? null,
-      raFeeling: raTicket.ra_feeling ?? null,
-      raCategories: raTicket.categories?.map(c => c.description) ?? [],
-      raPublicTreatmentTime: raTicket.public_treatment_time ?? null,
-      raPrivateTreatmentTime: raTicket.private_treatment_time ?? null,
-      raRatingDate: raTicket.rating_date ? new Date(raTicket.rating_date) : null,
-      raCommentsCount: raTicket.comments_count ?? 0,
-      raUnreadCount: raTicket.interactions_not_readed_count ?? 0,
-      raWhatsappEvalSent: raTicket.whatsapp?.sent ?? null,
-      raWhatsappEvalDone: raTicket.whatsapp?.evaluated ?? null,
-      raActive: raTicket.active ?? true,
-      raModerationStatus: raTicket.moderation?.status ?? null,
-      raConsumerConsideration: raTicket.consumer_consideration ?? null,
-      raCompanyConsideration: raTicket.company_consideration ?? null,
-    },
+  // Update ticket RA fields + sync ticket-level attachments
+  await prisma.$transaction(async (tx) => {
+    await tx.ticket.update({
+      where: { id: existingTicket.id },
+      data: {
+        status: ticketStatus,
+        raStatusId,
+        raStatusName,
+        raCanEvaluate: raTicket.request_evaluation ?? false,
+        raCanModerate: raTicket.request_moderation ?? false,
+        raRating: raTicket.rating,
+        raResolvedIssue: raTicket.resolved_issue,
+        raBackDoingBusiness: raTicket.back_doing_business,
+        raFrozen: raStatusId === 10,
+        raReason: raTicket.ra_reason ?? null,
+        raFeeling: raTicket.ra_feeling ?? null,
+        raCategories: raTicket.categories?.map(c => c.description) ?? [],
+        raPublicTreatmentTime: raTicket.public_treatment_time ?? null,
+        raPrivateTreatmentTime: raTicket.private_treatment_time ?? null,
+        raRatingDate: raTicket.rating_date ? new Date(raTicket.rating_date) : null,
+        raCommentsCount: raTicket.comments_count ?? 0,
+        raUnreadCount: raTicket.interactions_not_readed_count ?? 0,
+        raWhatsappEvalSent: raTicket.whatsapp?.sent ?? null,
+        raWhatsappEvalDone: raTicket.whatsapp?.evaluated ?? null,
+        raActive: raTicket.active ?? true,
+        raModerationStatus: raTicket.moderation?.status ?? null,
+        raConsumerConsideration: raTicket.consumer_consideration ?? null,
+        raCompanyConsideration: raTicket.company_consideration ?? null,
+      },
+    });
+
+    // Sync ticket-level attachments (may have new ones on re-sync)
+    await syncTicketAttachments(tx, existingTicket.id, raTicket);
   });
 
   // Create new messages
   for (const interaction of newInteractions) {
     try {
-      await createTicketMessage(prisma, existingTicket.id, interaction);
+      await createTicketMessage(prisma, existingTicket.id, interaction, raClient);
     } catch (err: unknown) {
       // Handle unique constraint violation (idempotent)
       if (
@@ -373,7 +524,8 @@ async function updateExistingTicket(
 async function createTicketMessage(
   tx: TxClient,
   ticketId: string,
-  interaction: RaInteraction
+  interaction: RaInteraction,
+  raClient?: ReclameAquiClient
 ): Promise<void> {
   const direction = mapInteractionDirection(
     interaction.ticket_interaction_type_id
@@ -381,7 +533,7 @@ async function createTicketMessage(
   const isInternal = interaction.privacy === "true" || interaction.privacy === "1" || interaction.privacy === true;
   const content = buildMessageContent(interaction);
 
-  await tx.ticketMessage.create({
+  const message = await tx.ticketMessage.create({
     data: {
       ticketId,
       senderId: null,
@@ -396,6 +548,15 @@ async function createTicketMessage(
         : new Date(),
     },
   });
+
+  // Sync interaction-level attachments (detail_type 15/33)
+  await syncInteractionAttachments(
+    tx,
+    ticketId,
+    message.id,
+    interaction.details,
+    raClient
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -476,7 +637,7 @@ export async function processReclameAquiInbound(_job: Job): Promise<void> {
 
         for (const raTicket of tickets) {
           try {
-            await processRaTicket(raTicket, ch.companyId, ch.id, summary);
+            await processRaTicket(raTicket, ch.companyId, ch.id, summary, client);
           } catch (_err) {
             summary.errors++;
             logger.error(

--- a/erp/src/lib/workers/whatsapp-outbound.ts
+++ b/erp/src/lib/workers/whatsapp-outbound.ts
@@ -43,10 +43,14 @@ export async function processWhatsAppOutbound(job: Job<WhatsAppOutboundJobData>)
       });
 
       for (const att of attachments) {
-        const mediaUrl = generateSignedFileUrl(att.storagePath, {
-          ttlSeconds: 15 * 60,
-        });
-        await sendMediaMessage(companyId, to, mediaUrl, att.fileName);
+        if (att.storagePath) {
+          const mediaUrl = generateSignedFileUrl(att.storagePath, {
+            ttlSeconds: 15 * 60,
+          });
+          await sendMediaMessage(companyId, to, mediaUrl, att.fileName);
+        } else if (att.externalUrl) {
+          await sendMediaMessage(companyId, to, att.externalUrl, att.fileName);
+        }
       }
     }
 


### PR DESCRIPTION
## O que mudou
- Sync de `attached[]` do ticket para model Attachment
- Sync de interaction details (type 15/33) para Attachment vinculado à TicketMessage
- Deduplicate por externalId para evitar duplicatas em re-syncs
- Fallback para endpoint `attachment/{id}` quando URL vazia
- Timeline renderiza imagens inline (thumbnails) e links de download
- Schema: campos `externalId`, `externalUrl` no Attachment, `storagePath` agora opcional
- Types: `RaAttachment` interface + `attached?` em `RaTicket`
- Outbound workers (email/whatsapp) adaptados para attachments externos