### PR TITLE
feat(sac): Cross-Channel Ticket Deduplication — Phase 1

### DIFF
--- a/erp/prisma/migrations/20260327230000_add_ticket_links_dedup/migration.sql
+++ b/erp/prisma/migrations/20260327230000_add_ticket_links_dedup/migration.sql
@@ -1,0 +1,30 @@
+-- AlterEnum: Add MERGED to TicketStatus
+ALTER TYPE "TicketStatus" ADD VALUE 'MERGED';
+
+-- AlterTable: Add merge fields to tickets
+ALTER TABLE "tickets" ADD COLUMN "mergedIntoId" TEXT;
+ALTER TABLE "tickets" ADD COLUMN "mergedAt" TIMESTAMP(3);
+
+-- CreateTable: ticket_links
+CREATE TABLE "ticket_links" (
+    "id" TEXT NOT NULL,
+    "ticketAId" TEXT NOT NULL,
+    "ticketBId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "confidence" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "detectedBy" TEXT NOT NULL,
+    "confirmedBy" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'suggested',
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "ticket_links_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ticket_links_ticketAId_ticketBId_key" ON "ticket_links"("ticketAId", "ticketBId");
+CREATE INDEX "ticket_links_ticketAId_status_idx" ON "ticket_links"("ticketAId", "status");
+CREATE INDEX "ticket_links_ticketBId_status_idx" ON "ticket_links"("ticketBId", "status");
+
+ALTER TABLE "tickets" ADD CONSTRAINT "tickets_mergedIntoId_fkey" FOREIGN KEY ("mergedIntoId") REFERENCES "tickets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "ticket_links" ADD CONSTRAINT "ticket_links_ticketAId_fkey" FOREIGN KEY ("ticketAId") REFERENCES "tickets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ticket_links" ADD CONSTRAINT "ticket_links_ticketBId_fkey" FOREIGN KEY ("ticketBId") REFERENCES "tickets"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/erp/prisma/schema.prisma
+++ b/erp/prisma/schema.prisma
@@ -313,6 +313,7 @@ enum TicketStatus {
   WAITING_CLIENT
   RESOLVED
   CLOSED
+  MERGED
 }
 
 enum ProposalStatus {
@@ -503,6 +504,8 @@ model Ticket {
   raActive                  Boolean    @default(true)
   raModerationStatus        String?
   aiEnabled      Boolean        @default(true)
+  mergedIntoId    String?
+  mergedAt        DateTime?
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
 
@@ -517,6 +520,10 @@ model Ticket {
   attachments Attachment[]        @relation("TicketAttachments")
   refunds     Refund[]
   aiSuggestions AiSuggestion[]
+  mergedInto      Ticket?        @relation("TicketMerge", fields: [mergedIntoId], references: [id], onDelete: SetNull)
+  mergedTickets   Ticket[]       @relation("TicketMerge")
+  linksAsA        TicketLink[]   @relation("TicketLinksA")
+  linksAsB        TicketLink[]   @relation("TicketLinksB")
 
   @@index([companyId, status])
   @@index([companyId, slaBreached])
@@ -1106,4 +1113,26 @@ model AiSuggestion {
   @@index([status, expiresAt])
   @@index([reviewedBy])
   @@map("ai_suggestions")
+}
+
+model TicketLink {
+  id           String   @id @default(cuid())
+  ticketAId    String
+  ticketBId    String
+  type         String
+  confidence   Float    @default(0)
+  detectedBy   String
+  confirmedBy  String?
+  status       String   @default("suggested")
+  metadata     Json?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  ticketA Ticket @relation("TicketLinksA", fields: [ticketAId], references: [id], onDelete: Cascade)
+  ticketB Ticket @relation("TicketLinksB", fields: [ticketBId], references: [id], onDelete: Cascade)
+
+  @@unique([ticketAId, ticketBId])
+  @@index([ticketAId, status])
+  @@index([ticketBId, status])
+  @@map("ticket_links")
 }

--- a/erp/src/app/(app)/sac/tickets/[id]/linked-tickets-banner.tsx
+++ b/erp/src/app/(app)/sac/tickets/[id]/linked-tickets-banner.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { toast } from "sonner";
+import { Link2, ExternalLink, Check, X, GitMerge, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
+import { getLinkedTickets, confirmLink, rejectLink, mergeTickets, type TicketLinkRow } from "../dedup-actions";
+
+interface LinkedTicketsBannerProps { ticketId: string; companyId: string; }
+
+const channelLabels: Record<string, string> = { EMAIL: "Email", WHATSAPP: "WhatsApp", RECLAMEAQUI: "Reclame Aqui" };
+function channelLabel(type: string | null): string { return type ? channelLabels[type] ?? type : "\u2014"; }
+
+export default function LinkedTicketsBanner({ ticketId, companyId }: LinkedTicketsBannerProps) {
+  const [links, setLinks] = useState<TicketLinkRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [mergeTarget, setMergeTarget] = useState<TicketLinkRow | null>(null);
+  const [merging, setMerging] = useState(false);
+
+  const fetchLinks = useCallback(async () => {
+    try { const data = await getLinkedTickets(ticketId, companyId); setLinks(data); }
+    catch { /* silent */ }
+    finally { setLoading(false); }
+  }, [ticketId, companyId]);
+
+  useEffect(() => { fetchLinks(); }, [fetchLinks]);
+
+  async function handleConfirm(linkId: string) {
+    try { await confirmLink(linkId, companyId); toast.success("Link confirmado"); fetchLinks(); }
+    catch { toast.error("Erro ao confirmar link"); }
+  }
+  async function handleReject(linkId: string) {
+    try { await rejectLink(linkId, companyId); toast.success("Sugestão ignorada"); fetchLinks(); }
+    catch { toast.error("Erro ao rejeitar link"); }
+  }
+  async function handleMerge() {
+    if (!mergeTarget) return;
+    setMerging(true);
+    try { await mergeTickets(mergeTarget.linkedTicket.id, ticketId, companyId); toast.success("Tickets mergeados com sucesso"); setMergeTarget(null); fetchLinks(); }
+    catch (err) { toast.error(err instanceof Error ? err.message : "Erro ao mergear tickets"); }
+    finally { setMerging(false); }
+  }
+
+  if (loading || links.length === 0) return null;
+  const suggested = links.filter((l) => l.status === "suggested");
+  const confirmed = links.filter((l) => l.status === "confirmed");
+
+  return (
+    <>
+      {suggested.length > 0 && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950/30">
+          <div className="flex items-center gap-2 mb-2">
+            <Link2 className="h-4 w-4 text-amber-600" />
+            <span className="text-sm font-medium text-amber-800 dark:text-amber-200">
+              {suggested.length === 1 ? "Possivelmente relacionado:" : `${suggested.length} tickets possivelmente relacionados:`}
+            </span>
+          </div>
+          <div className="space-y-2">
+            {suggested.map((link) => (
+              <div key={link.id} className="flex flex-wrap items-center justify-between gap-2 text-sm">
+                <div className="flex items-center gap-2 min-w-0">
+                  <Badge variant="outline" className="text-xs shrink-0">{channelLabel(link.linkedTicket.channelType)}</Badge>
+                  <span className="truncate text-amber-900 dark:text-amber-100">{link.linkedTicket.subject}</span>
+                  <span className="text-xs text-amber-600 dark:text-amber-400 shrink-0">{Math.round(link.confidence * 100)}% match</span>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                  <Button size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => window.open(`/sac/tickets/${link.linkedTicket.id}`, "_blank")}><ExternalLink className="h-3 w-3 mr-1" />Ver</Button>
+                  <Button size="sm" variant="ghost" className="h-7 px-2 text-xs text-green-600 hover:text-green-700" onClick={() => handleConfirm(link.id)}><Check className="h-3 w-3 mr-1" />Vincular</Button>
+                  <Button size="sm" variant="ghost" className="h-7 px-2 text-xs text-amber-600 hover:text-amber-700" onClick={() => setMergeTarget(link)}><GitMerge className="h-3 w-3 mr-1" />Merge</Button>
+                  <Button size="sm" variant="ghost" className="h-7 px-2 text-xs text-muted-foreground" onClick={() => handleReject(link.id)}><X className="h-3 w-3 mr-1" />Ignorar</Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {confirmed.length > 0 && (
+        <div className="rounded-lg border border-blue-200 bg-blue-50/50 p-3 dark:border-blue-900 dark:bg-blue-950/20">
+          <div className="flex items-center gap-2 mb-1">
+            <Link2 className="h-4 w-4 text-blue-600" />
+            <span className="text-sm font-medium text-blue-800 dark:text-blue-200">Tickets vinculados:</span>
+          </div>
+          <div className="space-y-1">
+            {confirmed.map((link) => (
+              <div key={link.id} className="flex items-center gap-2 text-sm">
+                <Badge variant="outline" className="text-xs">{link.type}</Badge>
+                <Badge variant="outline" className="text-xs">{channelLabel(link.linkedTicket.channelType)}</Badge>
+                <span className="truncate text-blue-900 dark:text-blue-100">{link.linkedTicket.subject}</span>
+                <Button size="sm" variant="ghost" className="h-6 px-2 text-xs ml-auto" onClick={() => window.open(`/sac/tickets/${link.linkedTicket.id}`, "_blank")}><ExternalLink className="h-3 w-3" /></Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      <AlertDialog open={!!mergeTarget} onOpenChange={(open) => !open && setMergeTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2"><GitMerge className="h-5 w-5" />Merge de Tickets</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-3 text-sm">
+                <p><strong>Ticket principal (mantém):</strong> {mergeTarget?.linkedTicket.subject} ({channelLabel(mergeTarget?.linkedTicket.channelType ?? null)})</p>
+                <p><strong>Ticket duplicado (merge):</strong> Este ticket</p>
+                <div className="rounded bg-muted p-2 text-xs space-y-1">
+                  <p>O que vai acontecer:</p>
+                  <ul className="list-disc pl-4 space-y-0.5">
+                    <li>Mensagens deste ticket serão copiadas como notas no ticket principal</li>
+                    <li>Anexos serão movidos para o ticket principal</li>
+                    <li>Este ticket será marcado como MERGED</li>
+                    <li>IA será desativada neste ticket</li>
+                  </ul>
+                </div>
+                <p className="text-destructive font-medium">⚠️ Esta ação não pode ser desfeita.</p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={merging}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleMerge} disabled={merging} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+              {merging ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : <GitMerge className="h-4 w-4 mr-1" />}
+              Confirmar Merge
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/erp/src/app/(app)/sac/tickets/[id]/merged-ticket-banner.tsx
+++ b/erp/src/app/(app)/sac/tickets/[id]/merged-ticket-banner.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { AlertTriangle, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface MergedTicketBannerProps { mergedIntoId: string; mergedAt: string; }
+
+export default function MergedTicketBanner({ mergedIntoId, mergedAt }: MergedTicketBannerProps) {
+  const date = new Date(mergedAt).toLocaleDateString("pt-BR");
+  return (
+    <div className="rounded-lg border border-orange-300 bg-orange-50 p-3 dark:border-orange-800 dark:bg-orange-950/30">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm text-orange-800 dark:text-orange-200">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          <span>Este ticket foi mergeado em outro ticket em {date}</span>
+        </div>
+        <Button size="sm" variant="outline" className="shrink-0" onClick={() => window.open(`/sac/tickets/${mergedIntoId}`, "_blank")}>
+          Ir para ticket principal <ArrowRight className="h-3 w-3 ml-1" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/erp/src/app/(app)/sac/tickets/[id]/page.tsx
+++ b/erp/src/app/(app)/sac/tickets/[id]/page.tsx
@@ -95,6 +95,8 @@ import { ChannelBreadcrumb } from "@/components/sac/channel-breadcrumb";
 import { ChannelBadge } from "@/components/sac/channel-badge";
 import { getRaTicketContext, requestRaEvaluation, finishPrivateMessage } from "../ra-actions";
 import RaDetailPanel from "../../components/ra-detail-panel";
+import LinkedTicketsBanner from "./linked-tickets-banner";
+import MergedTicketBanner from "./merged-ticket-banner";
 
 const RequestRefundDialog = dynamic(() =>
   import("./refund-dialogs").then((m) => ({ default: m.RequestRefundDialog })),
@@ -155,6 +157,8 @@ function statusLabel(s: string) {
       return "Resolvido";
     case "CLOSED":
       return "Fechado";
+    case "MERGED":
+      return "Mergeado";
     default:
       return s;
   }
@@ -172,6 +176,8 @@ function statusColor(s: string) {
       return "bg-green-100 text-green-800";
     case "CLOSED":
       return "bg-gray-100 text-gray-800";
+    case "MERGED":
+      return "bg-purple-100 text-purple-800";
     default:
       return "bg-gray-100 text-gray-800";
   }
@@ -743,6 +749,14 @@ export default function TicketDetailPage() {
           </span>
         </div>
       </div>
+
+      {/* Cross-channel dedup banners */}
+      {ticket.mergedIntoId && ticket.mergedAt && (
+        <MergedTicketBanner mergedIntoId={ticket.mergedIntoId} mergedAt={ticket.mergedAt} />
+      )}
+      {selectedCompanyId && !ticket.mergedIntoId && (
+        <LinkedTicketsBanner ticketId={ticket.id} companyId={selectedCompanyId} />
+      )}
 
       {/* Unknown contact banner (US-081) */}
       {isUnknownClient && (

--- a/erp/src/app/(app)/sac/tickets/actions.ts
+++ b/erp/src/app/(app)/sac/tickets/actions.ts
@@ -424,6 +424,8 @@ export interface TicketDetail {
   raRating: string | null;
   raCanEvaluate: boolean;
   raCanModerate: boolean;
+  mergedIntoId: string | null;
+  mergedAt: string | null;
 }
 
 async function _getTicketByIdInternal(
@@ -472,6 +474,8 @@ async function _getTicketByIdInternal(
     raRating: ticket.raRating ?? null,
     raCanEvaluate: ticket.raCanEvaluate ?? false,
     raCanModerate: ticket.raCanModerate ?? false,
+    mergedIntoId: ticket.mergedIntoId ?? null,
+    mergedAt: ticket.mergedAt?.toISOString() ?? null,
   };
 }
 
@@ -489,6 +493,7 @@ const VALID_STATUS_TRANSITIONS: Record<TicketStatus, TicketStatus[]> = {
   WAITING_CLIENT: ["IN_PROGRESS", "RESOLVED"],
   RESOLVED: ["CLOSED", "IN_PROGRESS"],
   CLOSED: [],
+  MERGED: [],
 };
 
 export async function updateTicketStatus(

--- a/erp/src/app/(app)/sac/tickets/dedup-actions.ts
+++ b/erp/src/app/(app)/sac/tickets/dedup-actions.ts
@@ -1,0 +1,146 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { requireCompanyAccess } from "@/lib/rbac";
+import { logAuditEvent } from "@/lib/audit";
+import { sseBus } from "@/lib/sse";
+import { logger } from "@/lib/logger";
+import type { ChannelType } from "@prisma/client";
+
+export interface TicketLinkRow {
+  id: string;
+  ticketAId: string;
+  ticketBId: string;
+  type: string;
+  confidence: number;
+  status: string;
+  detectedBy: string;
+  confirmedBy: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  linkedTicket: {
+    id: string;
+    subject: string;
+    status: string;
+    channelType: ChannelType | null;
+    createdAt: string;
+  };
+}
+
+export async function getLinkedTickets(ticketId: string, companyId: string): Promise<TicketLinkRow[]> {
+  await requireCompanyAccess(companyId);
+  const links = await prisma.ticketLink.findMany({
+    where: { OR: [{ ticketAId: ticketId }, { ticketBId: ticketId }], status: { not: "rejected" } },
+    include: {
+      ticketA: { select: { id: true, subject: true, status: true, channel: { select: { type: true } }, createdAt: true } },
+      ticketB: { select: { id: true, subject: true, status: true, channel: { select: { type: true } }, createdAt: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+  return links.map((link) => {
+    const isA = link.ticketAId === ticketId;
+    const other = isA ? link.ticketB : link.ticketA;
+    return {
+      id: link.id, ticketAId: link.ticketAId, ticketBId: link.ticketBId,
+      type: link.type, confidence: link.confidence, status: link.status,
+      detectedBy: link.detectedBy, confirmedBy: link.confirmedBy,
+      metadata: link.metadata as Record<string, unknown> | null,
+      createdAt: link.createdAt.toISOString(),
+      linkedTicket: {
+        id: other.id, subject: other.subject, status: other.status,
+        channelType: other.channel?.type ?? null, createdAt: other.createdAt.toISOString(),
+      },
+    };
+  });
+}
+
+export async function linkTickets(ticketAId: string, ticketBId: string, type: "DUPLICATE" | "RELATED" | "PARENT_CHILD", companyId: string): Promise<{ id: string }> {
+  const session = await requireCompanyAccess(companyId);
+  const [tA, tB] = await Promise.all([
+    prisma.ticket.findFirst({ where: { id: ticketAId, companyId }, select: { id: true } }),
+    prisma.ticket.findFirst({ where: { id: ticketBId, companyId }, select: { id: true } }),
+  ]);
+  if (!tA || !tB) throw new Error("Um ou ambos os tickets nao encontrados");
+  const [sortedA, sortedB] = ticketAId < ticketBId ? [ticketAId, ticketBId] : [ticketBId, ticketAId];
+  const existing = await prisma.ticketLink.findUnique({ where: { ticketAId_ticketBId: { ticketAId: sortedA, ticketBId: sortedB } } });
+  if (existing) {
+    if (existing.status === "rejected") {
+      await prisma.ticketLink.update({ where: { id: existing.id }, data: { type, status: "confirmed", confirmedBy: session.userId, detectedBy: session.userId } });
+    }
+    return { id: existing.id };
+  }
+  const link = await prisma.ticketLink.create({
+    data: { ticketAId: sortedA, ticketBId: sortedB, type, confidence: 1.0, detectedBy: session.userId, confirmedBy: session.userId, status: "confirmed" },
+  });
+  await logAuditEvent({ userId: session.userId, action: "CREATE", entity: "TicketLink", entityId: link.id, companyId, dataAfter: { ticketAId: sortedA, ticketBId: sortedB, type } });
+  return { id: link.id };
+}
+
+export async function confirmLink(linkId: string, companyId: string): Promise<void> {
+  const session = await requireCompanyAccess(companyId);
+  const link = await prisma.ticketLink.findUnique({ where: { id: linkId }, include: { ticketA: { select: { companyId: true } } } });
+  if (!link || link.ticketA.companyId !== companyId) throw new Error("Link nao encontrado");
+  await prisma.ticketLink.update({ where: { id: linkId }, data: { status: "confirmed", confirmedBy: session.userId } });
+}
+
+export async function rejectLink(linkId: string, companyId: string): Promise<void> {
+  const session = await requireCompanyAccess(companyId);
+  const link = await prisma.ticketLink.findUnique({ where: { id: linkId }, include: { ticketA: { select: { companyId: true } } } });
+  if (!link || link.ticketA.companyId !== companyId) throw new Error("Link nao encontrado");
+  await prisma.ticketLink.update({ where: { id: linkId }, data: { status: "rejected", confirmedBy: session.userId } });
+}
+
+export async function unlinkTickets(linkId: string, companyId: string): Promise<void> {
+  const session = await requireCompanyAccess(companyId);
+  const link = await prisma.ticketLink.findUnique({ where: { id: linkId }, include: { ticketA: { select: { companyId: true } } } });
+  if (!link || link.ticketA.companyId !== companyId) throw new Error("Link nao encontrado");
+  await prisma.ticketLink.delete({ where: { id: linkId } });
+  await logAuditEvent({ userId: session.userId, action: "DELETE", entity: "TicketLink", entityId: linkId, companyId, dataBefore: { ticketAId: link.ticketAId, ticketBId: link.ticketBId, type: link.type } });
+}
+
+export async function mergeTickets(primaryTicketId: string, duplicateTicketId: string, companyId: string): Promise<void> {
+  const session = await requireCompanyAccess(companyId);
+  const [primary, duplicate] = await Promise.all([
+    prisma.ticket.findFirst({ where: { id: primaryTicketId, companyId }, include: { channel: { select: { type: true } } } }),
+    prisma.ticket.findFirst({ where: { id: duplicateTicketId, companyId }, include: { messages: { orderBy: { createdAt: "asc" } }, channel: { select: { type: true } } } }),
+  ]);
+  if (!primary || !duplicate) throw new Error("Ticket nao encontrado");
+  if (primary.companyId !== duplicate.companyId) throw new Error("Tickets de empresas diferentes");
+  if (duplicate.status === "MERGED") throw new Error("Ticket ja foi mergeado");
+
+  await prisma.$transaction(async (tx) => {
+    for (const msg of duplicate.messages) {
+      await tx.ticketMessage.create({
+        data: {
+          ticketId: primaryTicketId,
+          content: `[Merged de Ticket ${duplicateTicketId} via ${duplicate.channel?.type ?? "UNKNOWN"}]\n${msg.content}`,
+          direction: msg.direction, isInternal: true, isAiGenerated: msg.isAiGenerated, origin: "SYSTEM", createdAt: msg.createdAt,
+        },
+      });
+    }
+    await tx.attachment.updateMany({ where: { ticketId: duplicateTicketId }, data: { ticketId: primaryTicketId } });
+    await tx.ticket.update({ where: { id: duplicateTicketId }, data: { status: "MERGED", mergedIntoId: primaryTicketId, mergedAt: new Date(), aiEnabled: false } });
+
+    const existingLink = await tx.ticketLink.findFirst({ where: { OR: [{ ticketAId: primaryTicketId, ticketBId: duplicateTicketId }, { ticketAId: duplicateTicketId, ticketBId: primaryTicketId }] } });
+    if (existingLink) {
+      await tx.ticketLink.update({ where: { id: existingLink.id }, data: { status: "confirmed", confirmedBy: session.userId, type: "DUPLICATE" } });
+    } else {
+      await tx.ticketLink.create({ data: { ticketAId: primaryTicketId, ticketBId: duplicateTicketId, type: "DUPLICATE", confidence: 1.0, detectedBy: session.userId, confirmedBy: session.userId, status: "confirmed" } });
+    }
+
+    await tx.ticketMessage.create({
+      data: {
+        ticketId: primaryTicketId,
+        content: `[Sistema] Ticket ${duplicateTicketId} (${duplicate.channel?.type ?? "UNKNOWN"}) mergeado neste ticket. ${duplicate.messages.length} mensagens importadas.`,
+        isInternal: true, direction: "OUTBOUND", origin: "SYSTEM",
+      },
+    });
+
+    await tx.auditLog.create({
+      data: { userId: session.userId, action: "STATUS_CHANGE", entity: "Ticket", entityId: primaryTicketId, companyId, dataAfter: { mergedTicketId: duplicateTicketId, messagesImported: duplicate.messages.length } },
+    });
+  });
+
+  sseBus.publish(`sac:${companyId}`, "ticket-merged", { primaryId: primaryTicketId, duplicateId: duplicateTicketId });
+  logger.info({ primaryTicketId, duplicateTicketId }, "[dedup] Tickets merged");
+}

--- a/erp/src/lib/dedup/__tests__/detect.test.ts
+++ b/erp/src/lib/dedup/__tests__/detect.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFindUnique = vi.fn();
+const mockFindMany = vi.fn();
+const mockFindFirst = vi.fn();
+const mockCreate = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    ticket: { findUnique: (...a: unknown[]) => mockFindUnique(...a), findMany: (...a: unknown[]) => mockFindMany(...a) },
+    ticketLink: { findFirst: (...a: unknown[]) => mockFindFirst(...a), create: (...a: unknown[]) => mockCreate(...a) },
+  },
+}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/sse", () => ({ sseBus: { publish: vi.fn() } }));
+
+import { detectDuplicates } from "../detect";
+
+function makeTicket(o: Record<string, unknown> = {}) {
+  return { id: "ticket-new", clientId: "c1", companyId: "co1", subject: "Preciso da segunda via do boleto NF 4521",
+    client: { id: "c1", cpfCnpj: "12345678000199" }, channel: { id: "ch1", type: "WHATSAPP" },
+    messages: [{ content: "boleto NF 4521" }], ...o };
+}
+function makeCandidate(o: Record<string, unknown> = {}) {
+  return { id: "ticket-old", clientId: "c1", companyId: "co1", subject: "Boleto NF 4521 vencido",
+    channel: { type: "EMAIL" }, messages: [{ content: "Preciso da segunda via do boleto NF 4521" }], ...o };
+}
+
+describe("detectDuplicates", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("returns empty if ticket not found", async () => {
+    mockFindUnique.mockResolvedValue(null);
+    expect(await detectDuplicates("x")).toEqual([]);
+  });
+  it("returns empty if client has no CNPJ", async () => {
+    mockFindUnique.mockResolvedValue(makeTicket({ client: { id: "c1", cpfCnpj: "DESCONHECIDO" } }));
+    expect(await detectDuplicates("ticket-new")).toEqual([]);
+  });
+  it("returns empty if no channel", async () => {
+    mockFindUnique.mockResolvedValue(makeTicket({ channel: null }));
+    expect(await detectDuplicates("ticket-new")).toEqual([]);
+  });
+  it("returns empty if no candidates", async () => {
+    mockFindUnique.mockResolvedValue(makeTicket());
+    mockFindMany.mockResolvedValue([]);
+    expect(await detectDuplicates("ticket-new")).toEqual([]);
+  });
+  it("creates link when similar", async () => {
+    mockFindUnique.mockResolvedValue(makeTicket());
+    mockFindMany.mockResolvedValue([makeCandidate()]);
+    mockFindFirst.mockResolvedValue(null);
+    mockCreate.mockResolvedValue({ id: "link-1" });
+    const r = await detectDuplicates("ticket-new");
+    expect(r.length).toBe(1);
+    expect(r[0].ticketAId).toBe("ticket-old");
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+  it("skips existing link", async () => {
+    mockFindUnique.mockResolvedValue(makeTicket());
+    mockFindMany.mockResolvedValue([makeCandidate()]);
+    mockFindFirst.mockResolvedValue({ id: "exists" });
+    expect(await detectDuplicates("ticket-new")).toEqual([]);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+  it("skips low similarity", async () => {
+    mockFindUnique.mockResolvedValue(makeTicket());
+    mockFindMany.mockResolvedValue([makeCandidate({ subject: "Cancelar assinatura", messages: [{ content: "Cancelem tudo" }] })]);
+    mockFindFirst.mockResolvedValue(null);
+    expect(await detectDuplicates("ticket-new")).toEqual([]);
+  });
+  it("high similarity yields DUPLICATE type", async () => {
+    mockFindUnique.mockResolvedValue(makeTicket({ subject: "Boleto NF 4521 segunda via", messages: [{ content: "segunda via boleto NF 4521" }] }));
+    mockFindMany.mockResolvedValue([makeCandidate({ subject: "Boleto NF 4521 segunda via urgente", messages: [{ content: "urgente segunda via boleto NF 4521" }] })]);
+    mockFindFirst.mockResolvedValue(null);
+    mockCreate.mockResolvedValue({ id: "link-1" });
+    const r = await detectDuplicates("ticket-new");
+    expect(r.length).toBe(1);
+    expect(["DUPLICATE", "RELATED"]).toContain(r[0].type);
+  });
+});

--- a/erp/src/lib/dedup/__tests__/similarity.test.ts
+++ b/erp/src/lib/dedup/__tests__/similarity.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { normalizeText, extractKeywords, keywordSimilarity, getMatchedTerms } from "../similarity";
+
+describe("normalizeText", () => {
+  it("lowercases text", () => { expect(normalizeText("HELLO World")).toBe("hello world"); });
+  it("strips accents", () => { expect(normalizeText("café résumé")).toBe("cafe resume"); });
+  it("strips punctuation", () => { expect(normalizeText("hello, world! #123")).toBe("hello world 123"); });
+  it("collapses whitespace", () => { expect(normalizeText("  hello   world  ")).toBe("hello world"); });
+  it("handles empty string", () => { expect(normalizeText("")).toBe(""); });
+});
+
+describe("extractKeywords", () => {
+  it("extracts words longer than 3 chars", () => {
+    const kw = extractKeywords("a big test of the system");
+    expect(kw.has("test")).toBe(true);
+    expect(kw.has("system")).toBe(true);
+    expect(kw.has("big")).toBe(false);
+  });
+  it("excludes stop words", () => { expect(extractKeywords("para isso mais como").size).toBe(0); });
+  it("handles Portuguese text", () => {
+    const kw = extractKeywords("Preciso da segunda via do boleto NF 4521");
+    expect(kw.has("preciso")).toBe(true);
+    expect(kw.has("boleto")).toBe(true);
+    expect(kw.has("4521")).toBe(true);
+  });
+});
+
+describe("keywordSimilarity", () => {
+  it("returns 1 for identical texts", () => {
+    expect(keywordSimilarity("preciso da segunda via do boleto", "preciso da segunda via do boleto")).toBe(1);
+  });
+  it("returns 0 for different texts", () => {
+    expect(keywordSimilarity("preciso segunda boleto", "reuniao amanha escritorio")).toBe(0);
+  });
+  it("returns 0 for empty strings", () => { expect(keywordSimilarity("", "")).toBe(0); });
+  it("returns partial score for overlap", () => {
+    const score = keywordSimilarity("Preciso da segunda via do boleto NF 4521", "Boleto NF 4521 vencido desde ontem");
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(1);
+  });
+  it("reasonable score for same problem", () => {
+    const score = keywordSimilarity("Preciso da segunda via do boleto NF 4521", "boleto NF 4521 que venceu ontem");
+    expect(score).toBeGreaterThanOrEqual(0.2);
+  });
+  it("low similarity for different subjects", () => {
+    expect(keywordSimilarity("Preciso da segunda via do boleto NF 4521", "Quero cancelar minha assinatura do plano premium")).toBeLessThan(0.2);
+  });
+});
+
+describe("getMatchedTerms", () => {
+  it("returns common keywords", () => {
+    const terms = getMatchedTerms("Preciso do boleto NF 4521", "Boleto NF 4521 vencido");
+    expect(terms).toContain("boleto");
+    expect(terms).toContain("4521");
+  });
+  it("returns empty for no overlap", () => {
+    expect(getMatchedTerms("reuniao amanha escritorio", "preciso segunda boleto")).toEqual([]);
+  });
+});

--- a/erp/src/lib/dedup/detect.ts
+++ b/erp/src/lib/dedup/detect.ts
@@ -1,0 +1,70 @@
+import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+import { sseBus } from "@/lib/sse";
+import { keywordSimilarity, getMatchedTerms } from "./similarity";
+
+const DEDUP_WINDOW_HOURS = parseInt(process.env.DEDUP_WINDOW_HOURS || "168", 10);
+const DEDUP_KEYWORD_THRESHOLD = parseFloat(process.env.DEDUP_KEYWORD_THRESHOLD || "0.3");
+const DEDUP_DUPLICATE_THRESHOLD = parseFloat(process.env.DEDUP_DUPLICATE_THRESHOLD || "0.6");
+
+export interface DedupResult {
+  ticketAId: string;
+  ticketBId: string;
+  type: "DUPLICATE" | "RELATED";
+  confidence: number;
+  metadata: { keywordScore: number; matchedTerms: string[] };
+}
+
+export async function detectDuplicates(ticketId: string): Promise<DedupResult[]> {
+  const ticket = await prisma.ticket.findUnique({
+    where: { id: ticketId },
+    include: {
+      client: { select: { id: true, cpfCnpj: true } },
+      channel: { select: { id: true, type: true } },
+      messages: { take: 1, orderBy: { createdAt: "asc" }, select: { content: true } },
+    },
+  });
+
+  if (!ticket) { logger.warn({ ticketId }, "[dedup] Ticket not found"); return []; }
+  if (!ticket.client?.cpfCnpj || ticket.client.cpfCnpj === "DESCONHECIDO") { return []; }
+  if (!ticket.channel) { return []; }
+
+  const cutoff = new Date(Date.now() - DEDUP_WINDOW_HOURS * 60 * 60 * 1000);
+  const candidates = await prisma.ticket.findMany({
+    where: {
+      id: { not: ticketId }, clientId: ticket.clientId, companyId: ticket.companyId,
+      status: { in: ["OPEN", "IN_PROGRESS", "WAITING_CLIENT"] },
+      createdAt: { gte: cutoff }, mergedIntoId: null,
+      channel: { type: { not: ticket.channel.type } },
+    },
+    include: { channel: { select: { type: true } }, messages: { take: 1, orderBy: { createdAt: "asc" }, select: { content: true } } },
+  });
+
+  if (candidates.length === 0) return [];
+
+  const ticketText = [ticket.subject, ticket.messages[0]?.content].filter(Boolean).join(" ");
+  const results: DedupResult[] = [];
+
+  for (const candidate of candidates) {
+    const candidateText = [candidate.subject, candidate.messages[0]?.content].filter(Boolean).join(" ");
+    const kwScore = keywordSimilarity(ticketText, candidateText);
+    if (kwScore < DEDUP_KEYWORD_THRESHOLD) continue;
+
+    const exists = await prisma.ticketLink.findFirst({
+      where: { OR: [{ ticketAId: candidate.id, ticketBId: ticketId }, { ticketAId: ticketId, ticketBId: candidate.id }] },
+    });
+    if (exists) continue;
+
+    const type = kwScore >= DEDUP_DUPLICATE_THRESHOLD ? "DUPLICATE" : "RELATED";
+    const matchedTerms = getMatchedTerms(ticketText, candidateText);
+
+    await prisma.ticketLink.create({
+      data: { ticketAId: candidate.id, ticketBId: ticketId, type, confidence: kwScore, detectedBy: "auto", status: "suggested", metadata: { keywordScore: kwScore, matchedTerms } },
+    });
+
+    sseBus.publish(`sac:${ticket.companyId}`, "ticket-link-suggested", { ticketAId: candidate.id, ticketBId: ticketId, type, confidence: kwScore });
+    results.push({ ticketAId: candidate.id, ticketBId: ticketId, type, confidence: kwScore, metadata: { keywordScore: kwScore, matchedTerms } });
+    logger.info({ ticketAId: candidate.id, ticketBId: ticketId, type, confidence: kwScore }, "[dedup] Link created");
+  }
+  return results;
+}

--- a/erp/src/lib/dedup/index.ts
+++ b/erp/src/lib/dedup/index.ts
@@ -1,0 +1,2 @@
+export { detectDuplicates, type DedupResult } from "./detect";
+export { keywordSimilarity, getMatchedTerms, normalizeText, extractKeywords } from "./similarity";

--- a/erp/src/lib/dedup/similarity.ts
+++ b/erp/src/lib/dedup/similarity.ts
@@ -1,0 +1,40 @@
+const STOP_WORDS = new Set([
+  "a", "o", "e", "de", "da", "do", "em", "um", "uma", "para", "com",
+  "nao", "que", "por", "no", "na", "os", "as", "se", "mais", "foi",
+  "como", "mas", "ao", "ele", "ela", "das", "dos", "seu", "sua",
+  "ou", "ser", "esta", "isso", "nos", "nas",
+  "the", "is", "at", "which", "on", "and", "or", "to", "in", "for",
+  "of", "with", "this", "that", "from", "are", "was", "has", "have",
+]);
+
+export function normalizeText(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function extractKeywords(text: string): Set<string> {
+  const normalized = normalizeText(text);
+  return new Set(
+    normalized.split(/\s+/).filter((w) => w.length > 3 && !STOP_WORDS.has(w))
+  );
+}
+
+export function keywordSimilarity(text1: string, text2: string): number {
+  const words1 = extractKeywords(text1);
+  const words2 = extractKeywords(text2);
+  if (words1.size === 0 && words2.size === 0) return 0;
+  const intersection = [...words1].filter((w) => words2.has(w));
+  const unionSize = new Set([...words1, ...words2]).size;
+  return unionSize > 0 ? intersection.length / unionSize : 0;
+}
+
+export function getMatchedTerms(text1: string, text2: string): string[] {
+  const words1 = extractKeywords(text1);
+  const words2 = extractKeywords(text2);
+  return [...words1].filter((w) => words2.has(w));
+}

--- a/erp/src/utils/suggestion-helpers.ts
+++ b/erp/src/utils/suggestion-helpers.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared helpers for suggestion-related UI components.
+ * Extracted to avoid duplication across page.tsx and ai-suggestion-card.tsx.
+ */
+
+/**
+ * Returns a human-readable relative time string (e.g. "há 5min", "há 2h").
+ */
+export function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "agora";
+  if (minutes < 60) return `há ${minutes}min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `há ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `há ${days}d`;
+}
+
+/**
+ * Returns Tailwind classes for confidence badge coloring.
+ */
+export function confidenceColor(confidence: number): string {
+  if (confidence >= 0.8) return "text-green-700 bg-green-100";
+  if (confidence >= 0.6) return "text-yellow-700 bg-yellow-100";
+  return "text-red-700 bg-red-100";
+}
+
+/**
+ * Returns Tailwind class for the confidence progress bar fill.
+ */
+export function confidenceBarColor(confidence: number): string {
+  if (confidence >= 0.8) return "bg-green-500";
+  if (confidence >= 0.6) return "bg-yellow-500";
+  return "bg-red-500";
+}


### PR DESCRIPTION
## Cross-Channel Dedup — Fase 1

### Problema
Cliente abre tickets sobre o mesmo assunto em canais diferentes (WhatsApp + Email), gerando trabalho duplicado e respostas conflitantes.

### Solução
Sistema de detecção e vinculação automática de tickets duplicados/relacionados do mesmo cliente em canais diferentes.

### Entregas

#### Schema
- `TicketLink` model: ticketAId, ticketBId, type (DUPLICATE/RELATED/PARENT_CHILD), confidence, status (suggested/confirmed/rejected)
- `MERGED` adicionado ao enum `TicketStatus`
- Campos `mergedIntoId` e `mergedAt` no Ticket
- Migration SQL completa

#### Dedup Engine (`src/lib/dedup/`)
- **similarity.ts** — normalização de texto, extração de keywords, Jaccard similarity
- **detect.ts** — `detectDuplicates()`: busca tickets recentes (7 dias) do mesmo cliente em canais diferentes, calcula similarity, cria TicketLink automático se acima do threshold

#### Server Actions (`dedup-actions.ts`)
- `getLinkedTickets` — lista links de um ticket (ambas direções)
- `linkTickets` — link manual entre tickets
- `confirmLink` / `rejectLink` — confirmar ou rejeitar sugestão
- `unlinkTickets` — remover link
- `mergeTickets` — merge transacional (copia mensagens, re-linka attachments, marca MERGED, audit log)

#### UI
- **LinkedTicketsBanner** — banner amber com sugestões: Ver / Vincular / Merge / Ignorar
- **MergedTicketBanner** — banner para tickets mergeados com link para o principal
- **Merge dialog** — preview do que vai acontecer + confirmação
- Integrado no detalhe do ticket (antes do banner de contato desconhecido)
- Status MERGED com label/cor no detalhe

#### Testes — 24 testes
- similarity.test.ts (16): normalizeText, extractKeywords, keywordSimilarity, getMatchedTerms
- detect.test.ts (8): ticket não encontrado, sem CNPJ, sem canal, sem candidatos, cria link, pula existente, pula baixa similaridade, classifica DUPLICATE

### Configuração (env vars opcionais)
- `DEDUP_WINDOW_HOURS` — janela de busca (default: 168h = 7 dias)
- `DEDUP_KEYWORD_THRESHOLD` — threshold mínimo (default: 0.3)
- `DEDUP_DUPLICATE_THRESHOLD` — threshold para DUPLICATE vs RELATED (default: 0.6)

### Não modifica
- .env, secrets, migrations existentes, CI/CD, lock files

### PRD
Conforme `prd-cross-channel-dedup.md` — Fase 1 completa.