### PR TITLE
feat(ai): AI Fallback Chain, Health Check & Recovery

### DIFF
--- a/erp/prisma/migrations/20260328090000_ai_fallback_health/migration.sql
+++ b/erp/prisma/migrations/20260328090000_ai_fallback_health/migration.sql
@@ -1,0 +1,43 @@
+-- CreateTable: AiProviderHealth
+CREATE TABLE "ai_provider_health" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "model" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "latencyMs" INTEGER,
+    "errorMessage" TEXT,
+    "checkedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ai_provider_health_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ai_provider_health_provider_checkedAt_idx" ON "ai_provider_health"("provider", "checkedAt");
+CREATE INDEX "ai_provider_health_status_idx" ON "ai_provider_health"("status");
+
+-- CreateTable: AiProviderIncident
+CREATE TABLE "ai_provider_incidents" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "model" TEXT NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL,
+    "resolvedAt" TIMESTAMP(3),
+    "durationMs" INTEGER,
+    "ticketsAffected" INTEGER NOT NULL DEFAULT 0,
+    "ticketsRecovered" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "ai_provider_incidents_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ai_provider_incidents_provider_createdAt_idx" ON "ai_provider_incidents"("provider", "createdAt");
+CREATE INDEX "ai_provider_incidents_resolvedAt_idx" ON "ai_provider_incidents"("resolvedAt");
+
+-- AlterTable: AiConfig — add fallback fields
+ALTER TABLE "ai_config" ADD COLUMN IF NOT EXISTS "fallbackChain" JSONB;
+ALTER TABLE "ai_config" ADD COLUMN IF NOT EXISTS "healthCheckEnabled" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "ai_config" ADD COLUMN IF NOT EXISTS "healthCheckIntervalMs" INTEGER NOT NULL DEFAULT 120000;
+ALTER TABLE "ai_config" ADD COLUMN IF NOT EXISTS "humanOnlyModeEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable: Ticket — add recovery flag
+ALTER TABLE "tickets" ADD COLUMN IF NOT EXISTS "aiPendingRecovery" BOOLEAN NOT NULL DEFAULT false;

--- a/erp/src/app/(app)/configuracoes/ai/components/tab-health.tsx
+++ b/erp/src/app/(app)/configuracoes/ai/components/tab-health.tsx
@@ -1,0 +1,481 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  HeartPulse,
+  Loader2,
+  RefreshCw,
+  AlertTriangle,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Activity,
+  Shield,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import {
+  getProviderHealth,
+  getProviderHistory,
+  configFallbackChain,
+} from "../health-actions";
+import type {
+  HealthDashboardData,
+  ProviderHealthHistoryEntry,
+} from "../health-actions";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface TabHealthProps {
+  companyId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Status helpers
+// ---------------------------------------------------------------------------
+
+function statusIcon(status: string) {
+  switch (status) {
+    case "up":
+      return <CheckCircle2 className="h-4 w-4 text-green-500" />;
+    case "degraded":
+      return <AlertTriangle className="h-4 w-4 text-yellow-500" />;
+    case "down":
+      return <XCircle className="h-4 w-4 text-red-500" />;
+    default:
+      return <Clock className="h-4 w-4 text-muted-foreground" />;
+  }
+}
+
+function statusBadge(status: string) {
+  switch (status) {
+    case "up":
+      return <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">UP</Badge>;
+    case "degraded":
+      return <Badge className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">DEGRADED</Badge>;
+    case "down":
+      return <Badge className="bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">DOWN</Badge>;
+    default:
+      return <Badge variant="outline">Desconhecido</Badge>;
+  }
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)} min`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
+function formatTimeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < 60_000) return "agora";
+  if (diff < 3_600_000) return `há ${Math.round(diff / 60_000)} min`;
+  if (diff < 86_400_000) return `há ${Math.round(diff / 3_600_000)}h`;
+  return new Date(iso).toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit" });
+}
+
+// ---------------------------------------------------------------------------
+// Latency sparkline (simple ASCII-style bar chart in CSS)
+// ---------------------------------------------------------------------------
+
+function LatencyBar({ entries }: { entries: ProviderHealthHistoryEntry[] }) {
+  if (entries.length === 0) return <span className="text-xs text-muted-foreground">Sem dados</span>;
+
+  const maxLatency = Math.max(...entries.map((e) => e.latencyMs ?? 0), 1);
+  // Take last 30 entries for display
+  const recent = entries.slice(-30);
+
+  return (
+    <div className="flex items-end gap-[2px] h-8">
+      {recent.map((entry, i) => {
+        const height = entry.latencyMs ? Math.max(2, (entry.latencyMs / maxLatency) * 100) : 2;
+        const color =
+          entry.status === "down"
+            ? "bg-red-500"
+            : entry.status === "degraded"
+              ? "bg-yellow-500"
+              : "bg-green-500";
+        return (
+          <div
+            key={i}
+            className={`w-1.5 rounded-t ${color}`}
+            style={{ height: `${height}%` }}
+            title={`${entry.latencyMs ?? "—"}ms — ${entry.status} — ${new Date(entry.checkedAt).toLocaleString("pt-BR")}`}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function TabHealth({ companyId }: TabHealthProps) {
+  const [data, setData] = useState<HealthDashboardData | null>(null);
+  const [history, setHistory] = useState<ProviderHealthHistoryEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [healthData, historyData] = await Promise.all([
+        getProviderHealth(companyId),
+        getProviderHistory(companyId, 24),
+      ]);
+      setData(healthData);
+      setHistory(historyData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erro ao carregar dados");
+    } finally {
+      setLoading(false);
+    }
+  }, [companyId]);
+
+  const handleToggleHealthCheck = useCallback(
+    async (enabled: boolean) => {
+      if (!data) return;
+      setSaving(true);
+      const result = await configFallbackChain(companyId, data.fallbackChain, enabled);
+      if (result.success) {
+        setData((prev) => (prev ? { ...prev, healthCheckEnabled: enabled } : prev));
+      }
+      setSaving(false);
+    },
+    [companyId, data],
+  );
+
+  // ── Initial state ────────────────────────────────────────────────────────
+  if (!data && !loading) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <HeartPulse className="h-5 w-5" />
+              Saúde dos Providers de IA
+            </CardTitle>
+            <CardDescription>
+              Monitore a disponibilidade e latência dos providers configurados
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col items-center justify-center py-8 gap-3">
+            <p className="text-sm text-muted-foreground">
+              Clique para carregar o status dos providers de IA.
+            </p>
+            <Button onClick={loadData} disabled={loading}>
+              <Activity className="mr-2 h-4 w-4" />
+              Carregar status
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center text-muted-foreground">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Carregando dados de saúde...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-3 text-muted-foreground">
+        <AlertTriangle className="h-6 w-6 text-red-500" />
+        <p className="text-sm">{error}</p>
+        <Button variant="outline" size="sm" onClick={loadData}>
+          Tentar novamente
+        </Button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  // Group history by provider:model
+  const historyByProvider: Record<string, ProviderHealthHistoryEntry[]> = {};
+  for (const entry of history) {
+    const key = `${entry.provider}:${entry.model}`;
+    if (!historyByProvider[key]) historyByProvider[key] = [];
+    historyByProvider[key].push(entry);
+  }
+
+  // Compute uptime per provider (last 24h from history)
+  const uptimeByProvider: Record<string, number> = {};
+  for (const [key, entries] of Object.entries(historyByProvider)) {
+    const total = entries.length;
+    const up = entries.filter((e) => e.status !== "down").length;
+    uptimeByProvider[key] = total > 0 ? (up / total) * 100 : 100;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Human-only mode alert */}
+      {data.humanOnlyMode && (
+        <Card className="border-red-500 bg-red-50 dark:bg-red-950">
+          <CardContent className="flex items-center gap-3 py-4">
+            <XCircle className="h-5 w-5 text-red-500 shrink-0" />
+            <div>
+              <p className="font-medium text-red-800 dark:text-red-200">
+                🔴 IA Offline — modo somente humano ativado
+              </p>
+              {data.pendingRecoveryCount > 0 && (
+                <p className="text-sm text-red-600 dark:text-red-300">
+                  {data.pendingRecoveryCount} ticket(s) aguardando processamento
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Status atual */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <HeartPulse className="h-5 w-5" />
+                Status dos Providers
+              </CardTitle>
+              <CardDescription>
+                Health check automático a cada 2 minutos
+              </CardDescription>
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="health-check-toggle"
+                  checked={data.healthCheckEnabled}
+                  onCheckedChange={handleToggleHealthCheck}
+                  disabled={saving}
+                />
+                <Label htmlFor="health-check-toggle" className="text-xs">
+                  Health check
+                </Label>
+              </div>
+              <Button variant="outline" size="sm" onClick={loadData} disabled={loading}>
+                <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+                Atualizar
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {data.statuses.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              Nenhum provider configurado ou verificado ainda.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {data.statuses.map((s) => {
+                const key = `${s.provider}:${s.model}`;
+                const providerHistory = historyByProvider[key] || [];
+                const uptime = uptimeByProvider[key] ?? 100;
+
+                return (
+                  <div
+                    key={key}
+                    className="flex items-center justify-between rounded-lg border p-3"
+                  >
+                    <div className="flex items-center gap-3">
+                      {statusIcon(s.status)}
+                      <div>
+                        <p className="font-medium text-sm capitalize">{s.provider}</p>
+                        <p className="text-xs text-muted-foreground font-mono">{s.model}</p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-4">
+                      {/* Latency sparkline */}
+                      <div className="hidden sm:block w-24">
+                        <LatencyBar entries={providerHistory} />
+                      </div>
+
+                      {/* Uptime */}
+                      <div className="text-right hidden md:block">
+                        <p className="text-xs text-muted-foreground">Uptime 24h</p>
+                        <p className={`text-sm font-mono ${uptime >= 99 ? "text-green-600" : uptime >= 95 ? "text-yellow-600" : "text-red-600"}`}>
+                          {uptime.toFixed(1)}%
+                        </p>
+                      </div>
+
+                      {/* Latency */}
+                      <div className="text-right">
+                        <p className="text-xs text-muted-foreground">Latência</p>
+                        <p className="text-sm font-mono">
+                          {s.latencyMs ? `${(s.latencyMs / 1000).toFixed(1)}s` : "—"}
+                        </p>
+                      </div>
+
+                      {/* Status badge */}
+                      {statusBadge(s.status)}
+
+                      {/* Time ago */}
+                      <span className="text-xs text-muted-foreground w-20 text-right">
+                        {formatTimeAgo(s.checkedAt)}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Fallback chain */}
+      {data.fallbackChain.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Shield className="h-5 w-5" />
+              Fallback Chain
+            </CardTitle>
+            <CardDescription>
+              Ordem de tentativa quando o provider primário falha
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {data.fallbackChain.map((entry, i) => (
+                <div
+                  key={i}
+                  className="flex items-center gap-3 rounded-lg border p-3"
+                >
+                  <span className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-bold">
+                    {i + 1}
+                  </span>
+                  <div>
+                    <p className="text-sm font-medium capitalize">{entry.provider}</p>
+                    <p className="text-xs text-muted-foreground font-mono">{entry.model}</p>
+                  </div>
+                  {i === 0 && (
+                    <Badge variant="outline" className="ml-auto">Primário</Badge>
+                  )}
+                  {i > 0 && i < data.fallbackChain.length - 1 && (
+                    <Badge variant="secondary" className="ml-auto">Fallback</Badge>
+                  )}
+                  {i === data.fallbackChain.length - 1 && i > 0 && (
+                    <Badge variant="secondary" className="ml-auto">Último recurso</Badge>
+                  )}
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Incidentes recentes */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <AlertTriangle className="h-5 w-5" />
+            Incidentes Recentes
+          </CardTitle>
+          <CardDescription>
+            Últimos 30 dias de downtime dos providers
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.incidents.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              ✅ Nenhum incidente nos últimos 30 dias.
+            </p>
+          ) : (
+            <div className="rounded-md border">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/50">
+                    <th className="px-4 py-2 text-left font-medium">Data</th>
+                    <th className="px-4 py-2 text-left font-medium">Provider</th>
+                    <th className="px-4 py-2 text-left font-medium">Status</th>
+                    <th className="px-4 py-2 text-right font-medium">Duração</th>
+                    <th className="px-4 py-2 text-right font-medium">Tickets</th>
+                    <th className="px-4 py-2 text-right font-medium">Recuperados</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.incidents.map((incident) => (
+                    <tr key={incident.id} className="border-b last:border-0">
+                      <td className="px-4 py-2 text-xs">
+                        {new Date(incident.startedAt).toLocaleDateString("pt-BR", {
+                          day: "2-digit",
+                          month: "2-digit",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </td>
+                      <td className="px-4 py-2">
+                        <span className="capitalize">{incident.provider}</span>
+                        <span className="text-xs text-muted-foreground ml-1">
+                          ({incident.model})
+                        </span>
+                      </td>
+                      <td className="px-4 py-2">
+                        {incident.resolvedAt ? (
+                          <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">Resolvido</Badge>
+                        ) : (
+                          <Badge className="bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">Em andamento</Badge>
+                        )}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-xs">
+                        {incident.resolvedAt
+                          ? formatDuration(incident.durationMs)
+                          : formatDuration(Date.now() - new Date(incident.startedAt).getTime())}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono">
+                        {incident.ticketsAffected}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono">
+                        {incident.ticketsRecovered}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Pending recovery */}
+      {data.pendingRecoveryCount > 0 && (
+        <Card className="border-yellow-500">
+          <CardContent className="flex items-center gap-3 py-4">
+            <Clock className="h-5 w-5 text-yellow-500 shrink-0" />
+            <div>
+              <p className="font-medium text-yellow-800 dark:text-yellow-200">
+                {data.pendingRecoveryCount} ticket(s) aguardando reprocessamento
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Serão processados automaticamente quando um provider ficar disponível.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/erp/src/app/(app)/configuracoes/ai/health-actions.ts
+++ b/erp/src/app/(app)/configuracoes/ai/health-actions.ts
@@ -1,0 +1,211 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { requireCompanyAccess } from "@/lib/rbac";
+import { requireAdmin } from "@/lib/session";
+import { logAuditEvent } from "@/lib/audit";
+import { encrypt } from "@/lib/encryption";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProviderHealthStatus {
+  provider: string;
+  model: string;
+  status: string;
+  latencyMs: number | null;
+  checkedAt: string;
+}
+
+export interface ProviderHealthHistoryEntry {
+  id: string;
+  provider: string;
+  model: string;
+  status: string;
+  latencyMs: number | null;
+  errorMessage: string | null;
+  checkedAt: string;
+}
+
+export interface ProviderIncident {
+  id: string;
+  provider: string;
+  model: string;
+  startedAt: string;
+  resolvedAt: string | null;
+  durationMs: number | null;
+  ticketsAffected: number;
+  ticketsRecovered: number;
+}
+
+export interface FallbackChainEntry {
+  provider: string;
+  model: string;
+}
+
+export interface HealthDashboardData {
+  statuses: ProviderHealthStatus[];
+  incidents: ProviderIncident[];
+  pendingRecoveryCount: number;
+  humanOnlyMode: boolean;
+  fallbackChain: FallbackChainEntry[];
+  healthCheckEnabled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// getProviderHealth — current status of all providers
+// ---------------------------------------------------------------------------
+
+export async function getProviderHealth(
+  companyId: string,
+): Promise<HealthDashboardData> {
+  await requireCompanyAccess(companyId);
+
+  // Get latest status per provider/model
+  const statuses = await prisma.aiProviderHealth.findMany({
+    distinct: ["provider", "model"],
+    orderBy: { checkedAt: "desc" },
+    select: {
+      provider: true,
+      model: true,
+      status: true,
+      latencyMs: true,
+      checkedAt: true,
+    },
+  });
+
+  // Get recent incidents (last 30 days)
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const incidents = await prisma.aiProviderIncident.findMany({
+    where: { createdAt: { gte: thirtyDaysAgo } },
+    orderBy: { startedAt: "desc" },
+    take: 20,
+  });
+
+  // Get pending recovery count
+  const pendingRecoveryCount = await prisma.ticket.count({
+    where: { aiPendingRecovery: true, companyId },
+  });
+
+  // Get company AI config for fallback chain & human-only mode
+  const aiConfig = await prisma.aiConfig.findFirst({
+    where: { companyId, channel: null },
+    select: {
+      humanOnlyModeEnabled: true,
+      fallbackChain: true,
+      healthCheckEnabled: true,
+    },
+  });
+
+  const fallbackChain = (aiConfig?.fallbackChain as FallbackChainEntry[] | null) ?? [];
+
+  return {
+    statuses: statuses.map((s) => ({
+      ...s,
+      checkedAt: s.checkedAt.toISOString(),
+    })),
+    incidents: incidents.map((i) => ({
+      id: i.id,
+      provider: i.provider,
+      model: i.model,
+      startedAt: i.startedAt.toISOString(),
+      resolvedAt: i.resolvedAt?.toISOString() ?? null,
+      durationMs: i.durationMs,
+      ticketsAffected: i.ticketsAffected,
+      ticketsRecovered: i.ticketsRecovered,
+    })),
+    pendingRecoveryCount,
+    humanOnlyMode: aiConfig?.humanOnlyModeEnabled ?? false,
+    fallbackChain,
+    healthCheckEnabled: aiConfig?.healthCheckEnabled ?? true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getProviderHistory — health check history for charts
+// ---------------------------------------------------------------------------
+
+export async function getProviderHistory(
+  companyId: string,
+  hours = 24,
+): Promise<ProviderHealthHistoryEntry[]> {
+  await requireCompanyAccess(companyId);
+
+  const since = new Date(Date.now() - hours * 60 * 60 * 1000);
+
+  const history = await prisma.aiProviderHealth.findMany({
+    where: { checkedAt: { gte: since } },
+    orderBy: { checkedAt: "asc" },
+    select: {
+      id: true,
+      provider: true,
+      model: true,
+      status: true,
+      latencyMs: true,
+      errorMessage: true,
+      checkedAt: true,
+    },
+  });
+
+  return history.map((h) => ({
+    ...h,
+    checkedAt: h.checkedAt.toISOString(),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// configFallbackChain — update fallback chain configuration
+// ---------------------------------------------------------------------------
+
+export async function configFallbackChain(
+  companyId: string,
+  chain: FallbackChainEntry[],
+  healthCheckEnabled?: boolean,
+): Promise<{ success: boolean; error?: string }> {
+  const session = await requireAdmin();
+  await requireCompanyAccess(companyId);
+
+  // Validate chain entries
+  const validProviders = ["openai", "anthropic", "deepseek", "grok", "qwen"];
+  for (const entry of chain) {
+    if (!validProviders.includes(entry.provider)) {
+      return { success: false, error: `Provider inválido: ${entry.provider}` };
+    }
+    if (!entry.model || entry.model.trim().length === 0) {
+      return { success: false, error: "Modelo não pode ser vazio" };
+    }
+  }
+
+  try {
+    const data: Record<string, unknown> = {
+      fallbackChain: chain.length > 0 ? chain : null,
+    };
+    if (healthCheckEnabled !== undefined) {
+      data.healthCheckEnabled = healthCheckEnabled;
+    }
+
+    await prisma.aiConfig.updateMany({
+      where: { companyId, channel: null },
+      data,
+    });
+
+    await logAuditEvent({
+      action: "ai_fallback_chain_updated",
+      userId: session.user.id,
+      companyId,
+      details: { chain, healthCheckEnabled },
+    });
+
+    logger.info(
+      { companyId, chainLength: chain.length, healthCheckEnabled },
+      "[health-actions] Fallback chain updated",
+    );
+
+    return { success: true };
+  } catch (error) {
+    logger.error({ companyId, error }, "[health-actions] Failed to update fallback chain");
+    return { success: false, error: "Erro ao salvar configuração" };
+  }
+}

--- a/erp/src/lib/workers/__tests__/ai-agent-fallback.test.ts
+++ b/erp/src/lib/workers/__tests__/ai-agent-fallback.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for AI Agent Worker — Fallback Chain Integration
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockRunAgent = vi.fn();
+const mockBuildFallbackChain = vi.fn().mockResolvedValue([]);
+const mockMarkTicketPendingRecovery = vi.fn().mockResolvedValue(undefined);
+const mockCheckRateLimit = vi.fn().mockResolvedValue({ allowed: true });
+const mockResolveAiConfigSelect = vi.fn().mockResolvedValue({
+  operationMode: "auto",
+  hybridThreshold: 0.8,
+  alwaysRequireApproval: [],
+  raMode: null,
+  raEscalationKeywords: [],
+  raPrivateBeforePublic: true,
+  raAutoRequestEvaluation: false,
+});
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    ticket: { update: vi.fn().mockResolvedValue({}), findUnique: vi.fn().mockResolvedValue(null) },
+    ticketMessage: { create: vi.fn().mockResolvedValue({}) },
+    aiConfig: { findFirst: vi.fn().mockResolvedValue(null) },
+  },
+}));
+
+vi.mock("@/lib/ai/agent", () => ({
+  runAgent: (...args: unknown[]) => mockRunAgent(...args),
+}));
+
+vi.mock("@/lib/ai/fallback", () => ({
+  buildFallbackChain: (...args: unknown[]) => mockBuildFallbackChain(...args),
+  isProviderError: (err: unknown) => {
+    if (err instanceof Error) {
+      const msg = err.message.toLowerCase();
+      return msg.includes("503") || msg.includes("timeout") || msg.includes("all providers");
+    }
+    return false;
+  },
+}));
+
+vi.mock("@/lib/ai/recovery", () => ({
+  markTicketPendingRecovery: (...args: unknown[]) => mockMarkTicketPendingRecovery(...args),
+}));
+
+vi.mock("@/lib/ai/rate-limiter", () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+}));
+
+vi.mock("@/lib/ai/resolve-config", () => ({
+  resolveAiConfigSelect: (...args: unknown[]) => mockResolveAiConfigSelect(...args),
+}));
+
+vi.mock("@/lib/ai/suggestion-mode", () => ({
+  calculateConfidence: vi.fn().mockReturnValue(0.5),
+  createAiSuggestion: vi.fn().mockResolvedValue("suggestion-id"),
+  shouldRunAsSuggestion: vi.fn().mockReturnValue(false),
+  shouldAutoExecuteHybrid: vi.fn().mockReturnValue(false),
+  approveSuggestion: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/queue", () => ({
+  reclameaquiOutboundQueue: { add: vi.fn().mockResolvedValue({}) },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import { processAiAgent } from "../ai-agent";
+import type { Job } from "bullmq";
+
+function createJob(data: Record<string, unknown>): Job {
+  return {
+    data: {
+      ticketId: "ticket-1",
+      companyId: "company-1",
+      messageContent: "Hello",
+      channel: "WHATSAPP",
+      ...data,
+    },
+    moveToDelayed: vi.fn(),
+    token: "token",
+  } as unknown as Job;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("processAiAgent — fallback integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds fallback chain and passes to runAgent", async () => {
+    const chain = [
+      { provider: "openai", model: "gpt-4o-mini", apiKey: "key1" },
+      { provider: "anthropic", model: "claude-haiku-4-20250414", apiKey: "key2" },
+    ];
+    mockBuildFallbackChain.mockResolvedValueOnce(chain);
+    mockRunAgent.mockResolvedValueOnce({
+      responded: true,
+      escalated: false,
+      iterations: 1,
+    });
+
+    await processAiAgent(createJob({}));
+
+    expect(mockBuildFallbackChain).toHaveBeenCalledWith("company-1", "WHATSAPP");
+    expect(mockRunAgent).toHaveBeenCalledWith(
+      "ticket-1",
+      "company-1",
+      "Hello",
+      "WHATSAPP",
+      expect.objectContaining({
+        fallbackChain: chain,
+      }),
+    );
+  });
+
+  it("does not pass fallbackChain if only one provider", async () => {
+    mockBuildFallbackChain.mockResolvedValueOnce([
+      { provider: "openai", model: "gpt-4o-mini", apiKey: "key1" },
+    ]);
+    mockRunAgent.mockResolvedValueOnce({
+      responded: true,
+      escalated: false,
+      iterations: 1,
+    });
+
+    await processAiAgent(createJob({}));
+
+    expect(mockRunAgent).toHaveBeenCalledWith(
+      "ticket-1",
+      "company-1",
+      "Hello",
+      "WHATSAPP",
+      expect.objectContaining({
+        fallbackChain: undefined,
+      }),
+    );
+  });
+
+  it("marks ticket for recovery on provider error", async () => {
+    mockBuildFallbackChain.mockResolvedValueOnce([]);
+    mockRunAgent.mockRejectedValueOnce(
+      new Error("All providers in fallback chain failed: openai/gpt-4o-mini: 503"),
+    );
+
+    await processAiAgent(createJob({}));
+
+    expect(mockMarkTicketPendingRecovery).toHaveBeenCalledWith("ticket-1");
+  });
+
+  it("re-throws non-provider errors", async () => {
+    mockBuildFallbackChain.mockResolvedValueOnce([]);
+    mockRunAgent.mockRejectedValueOnce(new Error("Invalid API key"));
+
+    await expect(processAiAgent(createJob({}))).rejects.toThrow("Invalid API key");
+    expect(mockMarkTicketPendingRecovery).not.toHaveBeenCalled();
+  });
+
+  it("marks RA ticket for recovery on provider error", async () => {
+    mockBuildFallbackChain.mockResolvedValueOnce([]);
+    mockRunAgent.mockRejectedValueOnce(new Error("503 Service Unavailable"));
+
+    await processAiAgent(createJob({ channel: "RECLAMEAQUI" }));
+
+    expect(mockMarkTicketPendingRecovery).toHaveBeenCalledWith("ticket-1");
+  });
+
+  it("logs recovery job processing", async () => {
+    mockBuildFallbackChain.mockResolvedValueOnce([]);
+    mockRunAgent.mockResolvedValueOnce({
+      responded: true,
+      escalated: false,
+      iterations: 1,
+    });
+
+    await processAiAgent(createJob({ isRecovery: true }));
+
+    // Should have logged the recovery info
+    const { logger } = await import("@/lib/logger");
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("recovery"),
+    );
+  });
+});

--- a/erp/src/lib/workers/ai-agent.ts
+++ b/erp/src/lib/workers/ai-agent.ts
@@ -14,6 +14,9 @@ import {
 } from "@/lib/ai/suggestion-mode";
 import type { OperationMode } from "@/lib/ai/suggestion-mode";
 import { checkRateLimit } from "@/lib/ai/rate-limiter";
+import { buildFallbackChain } from "@/lib/ai/fallback";
+import { isProviderError } from "@/lib/ai/fallback";
+import { markTicketPendingRecovery } from "@/lib/ai/recovery";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -27,6 +30,8 @@ interface AiAgentJobData {
   channel?: "WHATSAPP" | "EMAIL" | "RECLAMEAQUI";
   /** Enriched RA ticket context for better AI suggestions */
   raContext?: import("@/lib/reclameaqui/types").RaAiContext;
+  /** Flag indicating this job was re-queued from recovery */
+  isRecovery?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -72,7 +77,11 @@ function computeConfidenceFromResult(result: AgentResult): number {
 // ---------------------------------------------------------------------------
 
 export async function processAiAgent(job: Job<AiAgentJobData>) {
-  const { ticketId, companyId, messageContent, messageId, channel = "WHATSAPP", raContext } = job.data;
+  const { ticketId, companyId, messageContent, messageId, channel = "WHATSAPP", raContext, isRecovery } = job.data;
+
+  if (isRecovery) {
+    logger.info(`[ai-agent] Processing recovery job for ticket ${ticketId}`);
+  }
 
   // 1. Rate Limit Check (per-ticket): AI toggle, budget, cooldown, interactions/hour
   const rateLimit = await checkRateLimit(ticketId, companyId, channel);
@@ -85,6 +94,9 @@ export async function processAiAgent(job: Job<AiAgentJobData>) {
     await job.moveToDelayed(Date.now() + rateLimit.delayMs, job.token);
     return;
   }
+
+  // ─── Build fallback chain for this company/channel ─────────────────────
+  const fallbackChain = await buildFallbackChain(companyId, channel);
 
   // ─── Resolve operation mode ─────────────────────────────────────────────
   const aiConfig = await resolveAiConfigSelect(companyId, channel, {
@@ -153,16 +165,30 @@ export async function processAiAgent(job: Job<AiAgentJobData>) {
       return;
     }
 
-    // Run the AI agent for RECLAMEAQUI
+    // Run the AI agent for RECLAMEAQUI (with fallback chain)
     const useSuggestionMode = shouldRunAsSuggestion(effectiveMode);
     logger.info(
-      `[ai-agent] Running RA agent for ticket ${ticketId}, company ${companyId}, mode=${effectiveMode}, suggestionMode=${useSuggestionMode}`
+      `[ai-agent] Running RA agent for ticket ${ticketId}, company ${companyId}, mode=${effectiveMode}, suggestionMode=${useSuggestionMode}, fallbackChain=${fallbackChain.length}`
     );
 
-    const result = await runAgent(ticketId, companyId, messageContent, "RECLAMEAQUI", {
-      suggestionMode: useSuggestionMode,
-      raContext,
-    });
+    let result: AgentResult;
+    try {
+      result = await runAgent(ticketId, companyId, messageContent, "RECLAMEAQUI", {
+        suggestionMode: useSuggestionMode,
+        raContext,
+        fallbackChain: fallbackChain.length > 1 ? fallbackChain : undefined,
+      });
+    } catch (error) {
+      if (isProviderError(error)) {
+        logger.warn(
+          { ticketId, companyId, error: error instanceof Error ? error.message : String(error) },
+          "[ai-agent] All providers failed for RA ticket, marking for recovery"
+        );
+        await markTicketPendingRecovery(ticketId);
+        return;
+      }
+      throw error;
+    }
 
     logger.info(
       `[ai-agent] RA agent completed for ticket ${ticketId}: responded=${result.responded}, escalated=${result.escalated}, iterations=${result.iterations}${result.error ? `, error=${result.error}` : ""}`
@@ -278,15 +304,29 @@ export async function processAiAgent(job: Job<AiAgentJobData>) {
     return;
   }
 
-  // 3. Run the AI agent loop for WHATSAPP / EMAIL
+  // 3. Run the AI agent loop for WHATSAPP / EMAIL (with fallback chain)
   const useSuggestionMode = shouldRunAsSuggestion(operationMode);
   logger.info(
-    `[ai-agent] Running agent for ticket ${ticketId}, company ${companyId}, channel ${channel}, mode=${operationMode}, suggestionMode=${useSuggestionMode}`
+    `[ai-agent] Running agent for ticket ${ticketId}, company ${companyId}, channel ${channel}, mode=${operationMode}, suggestionMode=${useSuggestionMode}, fallbackChain=${fallbackChain.length}`
   );
 
-  const result = await runAgent(ticketId, companyId, messageContent, channel, {
-    suggestionMode: useSuggestionMode,
-  });
+  let result: AgentResult;
+  try {
+    result = await runAgent(ticketId, companyId, messageContent, channel, {
+      suggestionMode: useSuggestionMode,
+      fallbackChain: fallbackChain.length > 1 ? fallbackChain : undefined,
+    });
+  } catch (error) {
+    if (isProviderError(error)) {
+      logger.warn(
+        { ticketId, companyId, channel, error: error instanceof Error ? error.message : String(error) },
+        "[ai-agent] All providers failed, marking ticket for recovery"
+      );
+      await markTicketPendingRecovery(ticketId);
+      return;
+    }
+    throw error;
+  }
 
   logger.info(
     `[ai-agent] Agent completed for ticket ${ticketId}: responded=${result.responded}, escalated=${result.escalated}, iterations=${result.iterations}${result.error ? `, error=${result.error}` : ""}`


### PR DESCRIPTION
## Resumo

Implementação do sistema de resiliência para providers de IA conforme [PRD AI Fallback v1.0](../dev/erp/prd-ai-fallback.md).

## O que foi feito

### 1. Migration SQL
- Tabela `ai_provider_health` — registra health checks periódicos (provider, model, status, latência)
- Tabela `ai_provider_incidents` — registra incidentes de downtime com duração e tickets afetados
- Campos no `ai_config`: `fallbackChain`, `healthCheckEnabled`, `healthCheckIntervalMs`, `humanOnlyModeEnabled`
- Campo no `tickets`: `aiPendingRecovery`

### 2. Health Checker (`health-checker.ts`) ✅ já existia
- `checkProviderHealth()` — mini-request "Reply OK", registra status UP/DOWN/DEGRADED
- `runHealthCheckCycle()` — testa todos os providers configurados
- `handleProviderDown/Up()` — cria/resolve incidentes, ativa/desativa human-only mode, SSE events
- `cleanupOldHealthChecks()` — retenção de 7 dias

### 3. Fallback Chain (`fallback.ts`) ✅ já existia
- `chatCompletionWithFallback()` — tenta cada provider na ordem, skip known-down, registra qual respondeu
- `buildFallbackChain()` — constrói chain a partir da config da empresa
- `isProviderError()` — classifica erros de provider vs erros de config

### 4. Recovery (`recovery.ts`) ✅ já existia
- `markTicketPendingRecovery()` — marca ticket + nota interna + incrementa incidente
- `processRecoveryQueue()` — reprocessa tickets pendentes em batch (FIFO por prioridade/SLA)

### 5. Integração com Worker (`ai-agent.ts`) ⭐ NOVO
- Build fallback chain antes de chamar `runAgent()`
- Passa `fallbackChain` para o agent quando há >1 provider
- Wrap com try/catch: erros de provider → `markTicketPendingRecovery()`
- Erros não-provider → re-throw normal
- Suporte a `isRecovery` flag no job data

### 6. Server Actions ⭐ NOVO
- `getProviderHealth()` — dashboard data (statuses, incidents, pending count, config)
- `getProviderHistory()` — histórico de health checks para gráficos (últimas 24h)
- `configFallbackChain()` — salvar/atualizar fallback chain com validação e audit log

### 7. Frontend TabHealth ⭐ NOVO
- Status atual dos providers com badge UP/DOWN/DEGRADED
- Sparkline de latência (últimas 30 medições)
- Uptime % nas últimas 24h
- Alerta visual quando human-only mode está ativo
- Tabela de incidentes recentes (30 dias)
- Visualização da fallback chain configurada
- Toggle de health check on/off
- Indicador de tickets pendentes de recovery

### 8. Testes ⭐ NOVO
- 6 testes de integração fallback no worker ai-agent
- Testes existentes: 13 fallback + 7 health-checker + 5 recovery = 25 testes

## Arquivos modificados

| Arquivo | Ação |
|---------|------|
| `prisma/migrations/20260328090000_ai_fallback_health/migration.sql` | Novo |
| `src/lib/workers/ai-agent.ts` | Modificado (+ fallback + recovery) |
| `src/app/(app)/configuracoes/ai/health-actions.ts` | Novo |
| `src/app/(app)/configuracoes/ai/components/tab-health.tsx` | Novo |
| `src/lib/workers/__tests__/ai-agent-fallback.test.ts` | Novo |

## Testes

```
✓ 41/42 testes passando
× 1 teste pré-existente em fallback.test.ts (mock issue, não relacionado)
```
