### PR TITLE
feat(sac): retry com backoff exponencial no outbound RA

### DIFF
--- a/erp/src/app/(app)/sac/tickets/[id]/ticket-timeline.tsx
+++ b/erp/src/app/(app)/sac/tickets/[id]/ticket-timeline.tsx
@@ -16,6 +16,7 @@ import {
   Bot,
   Wifi,
   RefreshCw,
+  AlertTriangle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -56,6 +57,7 @@ import {
 import { getWhatsAppStatus } from "../../../configuracoes/canais/actions";
 import { useEventStream } from "@/hooks/use-event-stream";
 import RaSuggestionCard from "./ra-suggestion-card";
+import { retryFailedRaMessage } from "../ra-actions";
 import AiSuggestionCard from "./components/ai-suggestion-card";
 import type { AiSuggestionData } from "./components/ai-suggestion-card";
 import { getSuggestions } from "./suggestion-actions";
@@ -250,6 +252,47 @@ function EventIcon({ event }: { event: TimelineEvent }) {
 // Timeline Event Item (Todos tab)
 // ---------------------------------------------------------------------------
 
+
+// ---------------------------------------------------------------------------
+// Retry Failed Button
+// ---------------------------------------------------------------------------
+
+function RetryFailedButton({ messageId, companyId, onRetry }: { messageId: string; companyId: string; onRetry?: () => void }) {
+  const [retrying, setRetrying] = useState(false);
+
+  async function handleRetry() {
+    setRetrying(true);
+    try {
+      const result = await retryFailedRaMessage(messageId, companyId);
+      if (result.success) {
+        toast.success("Mensagem reenviada para fila de envio");
+        onRetry?.();
+      } else {
+        toast.error(result.error ?? "Erro ao reenviar mensagem");
+      }
+    } catch {
+      toast.error("Erro ao reenviar mensagem");
+    } finally {
+      setRetrying(false);
+    }
+  }
+
+  return (
+    <div className="mt-2">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleRetry}
+        disabled={retrying}
+        className="text-xs border-red-300 text-red-700 hover:bg-red-50"
+      >
+        <RefreshCw className={`mr-1 h-3 w-3 ${retrying ? "animate-spin" : ""}`} />
+        {retrying ? "Reenviando..." : "Tentar novamente"}
+      </Button>
+    </div>
+  );
+}
+
 function TimelineItem({ event, channelType, companyId, ticketId, onActionComplete, isGrouped }: { event: TimelineEvent; channelType?: string | null; companyId: string; ticketId: string; onActionComplete?: () => void; isGrouped?: boolean }) {
   // AI-generated suggestion pending approval → render SuggestionCard
   if (event.isAiGenerated && event.deliveryStatus === "PENDING_APPROVAL") {
@@ -385,7 +428,18 @@ function TimelineItem({ event, channelType, companyId, ticketId, onActionComplet
               Descartada
             </Badge>
           )}
+          {event.deliveryStatus === "FAILED" && (
+            <Badge variant="destructive" className="text-xs px-1.5 py-0">
+              <AlertTriangle className="mr-1 h-3 w-3" />
+              Falha no envio
+            </Badge>
+          )}
         </div>
+
+        {/* Retry button for FAILED messages */}
+        {event.deliveryStatus === "FAILED" && event.channel === "RECLAMEAQUI" && event.direction === "OUTBOUND" && (
+          <RetryFailedButton messageId={event.id} companyId={companyId} onRetry={onActionComplete} />
+        )}
 
         {/* Content */}
         {event.type === "status_change" ? (

--- a/erp/src/app/(app)/sac/tickets/ra-actions.ts
+++ b/erp/src/app/(app)/sac/tickets/ra-actions.ts
@@ -15,6 +15,18 @@ import { promises as fs } from "fs";
 import crypto from "crypto";
 
 // ---------------------------------------------------------------------------
+// Shared BullMQ job options for RA outbound jobs
+// ---------------------------------------------------------------------------
+
+const RA_OUTBOUND_JOB_OPTS = {
+  attempts: 3,
+  backoff: { type: "exponential" as const, delay: 5000 },
+  removeOnComplete: { age: 86400, count: 1000 },
+  removeOnFail: { age: 604800 },
+} as const;
+
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -363,7 +375,7 @@ export async function approveSuggestion(
         publicMessage,
         privateMessage,
         email: clientEmail,
-      });
+      }, RA_OUTBOUND_JOB_OPTS);
     } else {
       // No email available — can only send public message
       await reclameaquiOutboundQueue.add("RA_SEND_PUBLIC", {
@@ -372,7 +384,7 @@ export async function approveSuggestion(
         raExternalId: message.ticket.raExternalId,
         companyId,
         message: publicMessage,
-      });
+      }, RA_OUTBOUND_JOB_OPTS);
     }
 
     await logAuditEvent({
@@ -504,7 +516,7 @@ export async function sendRaResponse(
       publicMessage: hasPublic ? publicMessage.trim() : undefined,
       privateMessage: hasPrivate ? privateMessage!.trim() : undefined,
       email: recipientEmail,
-    });
+    }, RA_OUTBOUND_JOB_OPTS);
 
     await logAuditEvent({
       userId: session.userId,
@@ -564,7 +576,7 @@ export async function requestRaEvaluation(
       ticketId,
       raExternalId: ticket.raExternalId,
       companyId,
-    });
+    }, RA_OUTBOUND_JOB_OPTS);
 
     await logAuditEvent({
       userId: session.userId,
@@ -639,7 +651,7 @@ export async function requestRaModeration(
       reason,
       message: message.trim(),
       migrateTO,
-    });
+    }, RA_OUTBOUND_JOB_OPTS);
 
     await logAuditEvent({
       userId: session.userId,
@@ -745,7 +757,7 @@ export async function finishPrivateMessage(
       ticketId: ticket.id,
       raExternalId: ticket.raExternalId,
       companyId,
-    });
+    }, RA_OUTBOUND_JOB_OPTS);
 
     await logAuditEvent({
       userId: session.userId,
@@ -854,7 +866,7 @@ export async function sendPrivateMessageWithAttachments(
       companyId,
       email: ticket.client.email,
       filePaths: filePaths.length > 0 ? filePaths : undefined,
-    });
+    }, RA_OUTBOUND_JOB_OPTS);
 
     await logAuditEvent({
       userId: session.userId,
@@ -937,7 +949,7 @@ export async function requestModerationWithAttachments(
       message: message.trim(),
       migrateTO,
       filePaths: filePaths.length > 0 ? filePaths : undefined,
-    });
+    }, RA_OUTBOUND_JOB_OPTS);
 
     await logAuditEvent({
       userId: session.userId,
@@ -957,6 +969,92 @@ export async function requestModerationWithAttachments(
     return { success: true };
   } catch (err) {
     logger.error({ err }, "[ra-actions] requestModerationWithAttachments error");
+    return { success: false, error: mapRaError(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 10. retryFailedRaMessage — retry a FAILED outbound message
+// ---------------------------------------------------------------------------
+
+export async function retryFailedRaMessage(
+  messageId: string,
+  companyId: string
+): Promise<RaActionResult> {
+  try {
+    const session = await requireCompanyAccess(companyId);
+
+    const message = await prisma.ticketMessage.findFirst({
+      where: { id: messageId },
+      include: {
+        ticket: {
+          select: {
+            id: true,
+            companyId: true,
+            raExternalId: true,
+            client: { select: { email: true } },
+            channel: { select: { type: true } },
+          },
+        },
+      },
+    });
+
+    if (!message) {
+      return { success: false, error: "Mensagem não encontrada" };
+    }
+
+    if (message.ticket.companyId !== companyId) {
+      return { success: false, error: "Acesso negado" };
+    }
+
+    if (message.deliveryStatus !== "FAILED") {
+      return { success: false, error: "Apenas mensagens com falha podem ser reenviadas" };
+    }
+
+    if (message.ticket.channel?.type !== "RECLAMEAQUI") {
+      return { success: false, error: "Este ticket não pertence ao canal Reclame Aqui" };
+    }
+
+    // Determine job type based on message properties
+    const isInternal = message.isInternal;
+    const jobName = isInternal ? "RA_SEND_PRIVATE" : "RA_SEND_PUBLIC";
+
+    // Update status to QUEUED
+    await prisma.ticketMessage.update({
+      where: { id: messageId },
+      data: { deliveryStatus: "QUEUED" },
+    });
+
+    // Re-enqueue
+    if (isInternal) {
+      await reclameaquiOutboundQueue.add(jobName, {
+        ticketId: message.ticket.id,
+        message: message.content,
+        email: message.ticket.client.email,
+      }, RA_OUTBOUND_JOB_OPTS);
+    } else {
+      await reclameaquiOutboundQueue.add(jobName, {
+        ticketId: message.ticket.id,
+        message: message.content,
+      }, RA_OUTBOUND_JOB_OPTS);
+    }
+
+    await logAuditEvent({
+      userId: session.userId,
+      action: "UPDATE",
+      entity: "TicketMessage",
+      entityId: messageId,
+      dataAfter: {
+        action: "RETRY_FAILED_RA_MESSAGE",
+        jobType: jobName,
+        deliveryStatus: "QUEUED",
+      } as unknown as Prisma.InputJsonValue,
+      companyId,
+    });
+
+    return { success: true };
+  } catch (err) {
+    logger.error({ err }, "[ra-actions] retryFailedRaMessage error");
     return { success: false, error: mapRaError(err) };
   }
 }

--- a/erp/src/lib/queue.ts
+++ b/erp/src/lib/queue.ts
@@ -39,11 +39,13 @@ const defaultJobOptions = {
   removeOnFail: { count: 5000 },
 }
 
-// Outbound RA jobs should NOT retry automatically (business logic errors, not transient)
-const noRetryJobOptions = {
-  attempts: 1,
-  removeOnComplete: { count: 1000 },
-  removeOnFail: { count: 5000 },
+// Outbound RA jobs: retry with exponential backoff (5s, 10s, 20s)
+// Error classification (retriable vs permanent) is handled in the worker
+const raOutboundJobOptions = {
+  attempts: 3,
+  backoff: { type: 'exponential' as const, delay: 5000 },
+  removeOnComplete: { age: 86400, count: 1000 },
+  removeOnFail: { age: 604800 },
 }
 
 // Extraction jobs
@@ -62,7 +64,7 @@ export const slaCheckQueue = new Queue(QUEUE_NAMES.SLA_CHECK, { connection })
 export const aiAgentQueue = new Queue(QUEUE_NAMES.AI_AGENT, { connection, defaultJobOptions })
 export const documentProcessingQueue = new Queue(QUEUE_NAMES.DOCUMENT_PROCESSING, { connection, defaultJobOptions })
 export const reclameaquiInboundQueue = new Queue(QUEUE_NAMES.RECLAMEAQUI_INBOUND, { connection, defaultJobOptions })
-export const reclameaquiOutboundQueue = new Queue(QUEUE_NAMES.RECLAMEAQUI_OUTBOUND, { connection, defaultJobOptions: noRetryJobOptions })
+export const reclameaquiOutboundQueue = new Queue(QUEUE_NAMES.RECLAMEAQUI_OUTBOUND, { connection, defaultJobOptions: raOutboundJobOptions })
 
 export const extractionQueue = new Queue(QUEUE_NAMES.ATTACHMENT_EXTRACTION, { connection, defaultJobOptions: extractionJobOptions })
 

--- a/erp/src/lib/workers/__tests__/reclameaqui-outbound-errors.test.ts
+++ b/erp/src/lib/workers/__tests__/reclameaqui-outbound-errors.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for error classification in the RA outbound worker.
+ * Verifies retriable vs permanent error codes are correctly classified.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+// Mock dependencies before importing the module under test
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+vi.mock("@/lib/encryption", () => ({ decryptConfig: vi.fn() }));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/sse", () => ({
+  sseBus: { publish: vi.fn() },
+}));
+vi.mock("@/lib/reclameaqui/client", () => {
+  class ReclameAquiError extends Error {
+    public code: number;
+    public statusCode: number;
+    constructor(message: string, code: number, statusCode = 0) {
+      super(message);
+      this.name = "ReclameAquiError";
+      this.code = code;
+      this.statusCode = statusCode;
+    }
+  }
+  return {
+    ReclameAquiError,
+    ReclameAquiClient: vi.fn(),
+  };
+});
+
+import { isRetriableError } from "../reclameaqui-outbound";
+import { ReclameAquiError } from "@/lib/reclameaqui/client";
+
+describe("isRetriableError", () => {
+  describe("retriable errors (should return true)", () => {
+    it("rate limit error (4290)", () => {
+      expect(isRetriableError(new ReclameAquiError("Rate limit", 4290))).toBe(true);
+    });
+
+    it("internal server error (5000)", () => {
+      expect(isRetriableError(new ReclameAquiError("Server error", 5000))).toBe(true);
+    });
+
+    it("service unavailable (5030)", () => {
+      expect(isRetriableError(new ReclameAquiError("Unavailable", 5030))).toBe(true);
+    });
+
+    it("network errors (plain Error)", () => {
+      expect(isRetriableError(new Error("ECONNRESET"))).toBe(true);
+    });
+
+    it("timeout errors", () => {
+      expect(isRetriableError(new Error("ETIMEDOUT"))).toBe(true);
+    });
+
+    it("unknown non-ReclameAquiError types", () => {
+      expect(isRetriableError("string error")).toBe(true);
+      expect(isRetriableError(null)).toBe(true);
+      expect(isRetriableError(undefined)).toBe(true);
+    });
+
+    it("unknown RA error code defaults to retriable", () => {
+      expect(isRetriableError(new ReclameAquiError("Unknown", 9999))).toBe(true);
+    });
+  });
+
+  describe("permanent errors (should return false)", () => {
+    const permanentCodes = [
+      [4090, "Ticket inactive"],
+      [4091, "Not RA ticket"],
+      [4095, "Already rated"],
+      [4096, "Not eligible for evaluation"],
+      [4098, "Attachment limit exceeded"],
+      [4099, "Daily moderation limit exceeded"],
+      [40910, "Moderation per complaint limit"],
+      [40912, "Moderation by duplicity impossible"],
+      [40913, "Moderation requires public response"],
+      [40914, "Moderation reason not allowed"],
+      [40915, "Not RA ticket (moderation)"],
+      [40916, "Pending moderation"],
+      [40917, "Moderation already requested"],
+      [40919, "Source doesn't support private messages"],
+      [40920, "Ticket closed"],
+      [40922, "Unsupported attachment type"],
+      [40925, "Private message already finished"],
+      [40930, "Duplicate message"],
+    ] as const;
+
+    it.each(permanentCodes)("code %d (%s)", (code, desc) => {
+      expect(isRetriableError(new ReclameAquiError(desc, code))).toBe(false);
+    });
+  });
+});

--- a/erp/src/lib/workers/reclameaqui-outbound.ts
+++ b/erp/src/lib/workers/reclameaqui-outbound.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { decryptConfig } from "@/lib/encryption";
 import { ReclameAquiClient, ReclameAquiError } from "@/lib/reclameaqui/client";
 import { logger } from "@/lib/logger";
+import { sseBus } from "@/lib/sse";
 import type { RaClientConfig } from "@/lib/reclameaqui/types";
 import type { MessageDeliveryStatus } from "@prisma/client";
 import { promises as fs } from "fs";
@@ -57,6 +58,79 @@ export type RaOutboundJobData =
   | RaFinishPrivateJobData;
 
 // ---------------------------------------------------------------------------
+// Error Classification
+// ---------------------------------------------------------------------------
+
+/**
+ * RA error codes that are RETRIABLE (transient failures).
+ * Rate limit (429), server errors (500, 503).
+ */
+const RETRIABLE_ERROR_CODES = new Set([4290, 5000, 5030]);
+
+/**
+ * RA error codes that are PERMANENT (no point retrying).
+ * Ticket inactive, already rated, moderation already requested, etc.
+ */
+const PERMANENT_ERROR_CODES = new Set([
+  4090,   // Ticket inactive
+  4091,   // Not RA ticket
+  4095,   // Already rated
+  4096,   // Not eligible for evaluation
+  4098,   // Attachment limit exceeded
+  4099,   // Daily moderation limit exceeded
+  40910,  // Moderation per complaint limit exceeded
+  40912,  // Moderation by duplicity impossible
+  40913,  // Moderation requires public response + evaluation
+  40914,  // Moderation reason not allowed
+  40915,  // Not RA ticket
+  40916,  // Already has pending moderation
+  40917,  // Moderation already requested
+  40919,  // Source doesn't support private messages
+  40920,  // Ticket closed, public message blocked
+  40922,  // Unsupported attachment type
+  40925,  // Private message already finished
+  40930,  // Duplicate message (handled separately)
+]);
+
+/**
+ * Classifies an error as retriable or permanent.
+ * - Network errors (no code) → retriable
+ * - Known transient codes → retriable
+ * - Known permanent codes → permanent
+ * - Unknown codes → retriable (safer to retry)
+ */
+export function isRetriableError(err: unknown): boolean {
+  if (!(err instanceof ReclameAquiError)) {
+    // Network errors, timeouts, etc → retry
+    return true;
+  }
+
+  if (PERMANENT_ERROR_CODES.has(err.code)) {
+    return false;
+  }
+
+  if (RETRIABLE_ERROR_CODES.has(err.code)) {
+    return true;
+  }
+
+  // Unknown RA error code → default to retriable
+  return true;
+}
+
+/**
+ * Custom error for permanent failures that should NOT be retried by BullMQ.
+ * We catch the original error and wrap it so we can return instead of throw.
+ */
+class PermanentRaError extends Error {
+  public readonly code: number;
+  constructor(code: number, message: string) {
+    super(message);
+    this.name = "PermanentRaError";
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -70,6 +144,9 @@ async function getTicketWithRaChannel(ticketId: string) {
     include: {
       channel: {
         select: { id: true, config: true, isActive: true, type: true },
+      },
+      company: {
+        select: { id: true },
       },
     },
   });
@@ -100,7 +177,7 @@ async function getTicketWithRaChannel(ticketId: string) {
     baseUrl: config.baseUrl,
   });
 
-  return { ticket, raExternalId: ticket.raExternalId, client };
+  return { ticket, raExternalId: ticket.raExternalId, client, companyId: ticket.company?.id ?? ticket.companyId };
 }
 
 /**
@@ -164,12 +241,125 @@ async function createOutboundMessage(params: {
   });
 }
 
+/**
+ * Structured log for outbound job attempts.
+ */
+function logJobAttempt(params: {
+  jobType: string;
+  ticketId: string;
+  attempt: number;
+  maxAttempts: number;
+  error: unknown;
+  willRetry: boolean;
+}) {
+  const errorInfo = params.error instanceof ReclameAquiError
+    ? { code: params.error.code, message: params.error.message }
+    : { message: String(params.error) };
+
+  logger.error(
+    {
+      jobType: params.jobType,
+      ticketId: params.ticketId,
+      attempt: params.attempt,
+      maxAttempts: params.maxAttempts,
+      error: errorInfo,
+      willRetry: params.willRetry,
+    },
+    `[reclameaqui-outbound] Job failed: ${params.jobType} for ticket ${params.ticketId} (attempt ${params.attempt}/${params.maxAttempts}, willRetry=${params.willRetry})`
+  );
+}
+
+/**
+ * Notify the frontend via SSE that a timeline update happened.
+ */
+function notifyTimelineUpdate(companyId: string, ticketId: string) {
+  sseBus.publish(`company:${companyId}:sac`, "timeline-update", {
+    ticketId,
+    timestamp: Date.now(),
+  });
+}
+
+/**
+ * Handles an error in an outbound job:
+ * - Duplicate → mark as SENT, return (no throw)
+ * - Permanent → create FAILED message, return (no throw = BullMQ won't retry)
+ * - Retriable → create FAILED message only on last attempt, throw (BullMQ retries)
+ */
+async function handleOutboundError(params: {
+  err: unknown;
+  job: Job;
+  ticketId: string;
+  companyId: string;
+  content: string;
+  isInternal: boolean;
+  onDuplicate?: () => Promise<void>;
+}): Promise<void> {
+  const { err, job, ticketId, companyId, content, isInternal, onDuplicate } = params;
+  const attempt = job.attemptsMade + 1;
+  const maxAttempts = job.opts?.attempts ?? 3;
+
+  // Duplicate → treat as success
+  if (isDuplicateError(err)) {
+    await createOutboundMessage({
+      ticketId,
+      content,
+      isInternal,
+      deliveryStatus: "SENT",
+    });
+    logger.warn(`[reclameaqui-outbound] Duplicate message for ticket ${ticketId}, marked as SENT`);
+    if (onDuplicate) await onDuplicate();
+    return;
+  }
+
+  const retriable = isRetriableError(err);
+  const isLastAttempt = attempt >= maxAttempts;
+  const willRetry = retriable && !isLastAttempt;
+
+  logJobAttempt({
+    jobType: job.name,
+    ticketId,
+    attempt,
+    maxAttempts,
+    error: err,
+    willRetry,
+  });
+
+  if (!retriable) {
+    // Permanent error → create FAILED message, don't throw (BullMQ won't retry)
+    await createOutboundMessage({
+      ticketId,
+      content,
+      isInternal,
+      deliveryStatus: "FAILED",
+    }).catch(() => {});
+
+    notifyTimelineUpdate(companyId, ticketId);
+    return;
+  }
+
+  // Retriable error
+  if (isLastAttempt) {
+    // Last attempt → create FAILED message + notify
+    await createOutboundMessage({
+      ticketId,
+      content,
+      isInternal,
+      deliveryStatus: "FAILED",
+    }).catch(() => {});
+
+    notifyTimelineUpdate(companyId, ticketId);
+  }
+
+  // Throw so BullMQ retries (or marks as failed on last attempt)
+  throw err;
+}
+
 // ---------------------------------------------------------------------------
 // Job Handlers
 // ---------------------------------------------------------------------------
 
-async function handleSendPublic(ticketId: string, message: string): Promise<void> {
-  const { ticket, raExternalId, client } = await getTicketWithRaChannel(ticketId);
+async function handleSendPublic(job: Job, ticketId: string, message: string): Promise<void> {
+  const { ticket, raExternalId, client, companyId } = await getTicketWithRaChannel(ticketId);
 
   try {
     await client.authenticate();
@@ -189,40 +379,26 @@ async function handleSendPublic(ticketId: string, message: string): Promise<void
 
     logger.info(`[reclameaqui-outbound] Public message sent for ticket ${ticket.id}`);
   } catch (err) {
-    if (isDuplicateError(err)) {
-      await createOutboundMessage({
-        ticketId: ticket.id,
-        content: message,
-        isInternal: false,
-        deliveryStatus: "SENT",
-      });
-      logger.warn(`[reclameaqui-outbound] Duplicate public message for ticket ${ticket.id}, marked as SENT`);
-      return;
-    }
-
-    await createOutboundMessage({
+    await handleOutboundError({
+      err,
+      job,
       ticketId: ticket.id,
+      companyId,
       content: message,
       isInternal: false,
-      deliveryStatus: "FAILED",
-    }).catch(() => {}); // Don't mask original error
-
-    logger.error(
-      { error: err instanceof ReclameAquiError ? { code: err.code, message: err.message } : String(err) },
-      `[reclameaqui-outbound] Failed to send public message for ticket ${ticket.id}`
-    );
-    throw err;
+    });
   }
 }
 
 async function handleSendPrivate(
+  job: Job,
   ticketId: string,
   message: string,
   email: string,
   filePaths?: string[],
   filesBase64?: string[]
 ): Promise<void> {
-  const { ticket, raExternalId, client } = await getTicketWithRaChannel(ticketId);
+  const { ticket, raExternalId, client, companyId } = await getTicketWithRaChannel(ticketId);
 
   try {
     await client.authenticate();
@@ -239,29 +415,14 @@ async function handleSendPrivate(
 
     logger.info(`[reclameaqui-outbound] Private message sent for ticket ${ticket.id}`);
   } catch (err) {
-    if (isDuplicateError(err)) {
-      await createOutboundMessage({
-        ticketId: ticket.id,
-        content: message,
-        isInternal: true,
-        deliveryStatus: "SENT",
-      });
-      logger.warn(`[reclameaqui-outbound] Duplicate private message for ticket ${ticket.id}, marked as SENT`);
-      return;
-    }
-
-    await createOutboundMessage({
+    await handleOutboundError({
+      err,
+      job,
       ticketId: ticket.id,
+      companyId,
       content: message,
       isInternal: true,
-      deliveryStatus: "FAILED",
-    }).catch(() => {});
-
-    logger.error(
-      { error: err instanceof ReclameAquiError ? { code: err.code, message: err.message } : String(err) },
-      `[reclameaqui-outbound] Failed to send private message for ticket ${ticket.id}`
-    );
-    throw err;
+    });
   } finally {
     // Always cleanup disk files, even on failure
     await cleanupFiles(filePaths);
@@ -269,12 +430,13 @@ async function handleSendPrivate(
 }
 
 async function handleSendDual(
+  job: Job,
   ticketId: string,
   privateMessage: string,
   publicMessage: string,
   email: string
 ): Promise<void> {
-  const { ticket, raExternalId, client } = await getTicketWithRaChannel(ticketId);
+  const { ticket, raExternalId, client, companyId } = await getTicketWithRaChannel(ticketId);
 
   await client.authenticate();
 
@@ -304,17 +466,27 @@ async function handleSendDual(
       logger.warn(`[reclameaqui-outbound] Dual: duplicate private message for ticket ${ticket.id}, marked as SENT`);
       privateFailed = false;
     } else {
-      await createOutboundMessage({
-        ticketId: ticket.id,
-        content: privateMessage,
-        isInternal: true,
-        deliveryStatus: "FAILED",
-      }).catch(() => {});
+      const retriable = isRetriableError(err);
+      const attempt = job.attemptsMade + 1;
+      const maxAttempts = job.opts?.attempts ?? 3;
 
-      logger.error(
-        { error: err instanceof ReclameAquiError ? { code: err.code, message: err.message } : String(err) },
-        `[reclameaqui-outbound] Dual: failed to send private message for ticket ${ticket.id}`
-      );
+      logJobAttempt({
+        jobType: job.name,
+        ticketId: ticket.id,
+        attempt,
+        maxAttempts,
+        error: err,
+        willRetry: retriable && attempt < maxAttempts,
+      });
+
+      if (!retriable || attempt >= maxAttempts) {
+        await createOutboundMessage({
+          ticketId: ticket.id,
+          content: privateMessage,
+          isInternal: true,
+          deliveryStatus: "FAILED",
+        }).catch(() => {});
+      }
     }
   }
 
@@ -345,28 +517,46 @@ async function handleSendDual(
       });
       logger.warn(`[reclameaqui-outbound] Dual: duplicate public message for ticket ${ticket.id}, marked as SENT`);
     } else {
-      await createOutboundMessage({
+      const retriable = isRetriableError(err);
+      const attempt = job.attemptsMade + 1;
+      const maxAttempts = job.opts?.attempts ?? 3;
+      const willRetry = retriable && attempt < maxAttempts;
+
+      logJobAttempt({
+        jobType: job.name,
         ticketId: ticket.id,
-        content: publicMessage,
-        isInternal: false,
-        deliveryStatus: "FAILED",
-      }).catch(() => {});
+        attempt,
+        maxAttempts,
+        error: err,
+        willRetry,
+      });
 
-      logger.error(
-        { error: err instanceof ReclameAquiError ? { code: err.code, message: err.message } : String(err) },
-        `[reclameaqui-outbound] Dual: failed to send public message for ticket ${ticket.id}`
-      );
+      if (!retriable || attempt >= maxAttempts) {
+        await createOutboundMessage({
+          ticketId: ticket.id,
+          content: publicMessage,
+          isInternal: false,
+          deliveryStatus: "FAILED",
+        }).catch(() => {});
 
-      // Only throw if both failed
-      if (privateFailed) {
+        notifyTimelineUpdate(companyId, ticket.id);
+      }
+
+      // Only throw if both failed (retriable) — or if public failed and should retry
+      if (privateFailed || willRetry) {
         throw err;
       }
     }
   }
+
+  // If private failed with a retriable error and public succeeded, still notify
+  if (privateFailed) {
+    notifyTimelineUpdate(companyId, ticket.id);
+  }
 }
 
-async function handleRequestEvaluation(ticketId: string): Promise<void> {
-  const { ticket, raExternalId, client } = await getTicketWithRaChannel(ticketId);
+async function handleRequestEvaluation(job: Job, ticketId: string): Promise<void> {
+  const { ticket, raExternalId, client, companyId } = await getTicketWithRaChannel(ticketId);
 
   if (!ticket.raCanEvaluate) {
     logger.warn(`[reclameaqui-outbound] Ticket ${ticket.id} cannot request evaluation (raCanEvaluate=false)`);
@@ -397,22 +587,19 @@ async function handleRequestEvaluation(ticketId: string): Promise<void> {
 
     logger.info(`[reclameaqui-outbound] Evaluation requested for ticket ${ticket.id}`);
   } catch (err) {
-    await createOutboundMessage({
+    await handleOutboundError({
+      err,
+      job,
       ticketId: ticket.id,
+      companyId,
       content: `[Sistema] Falha ao solicitar avaliação: ${err instanceof ReclameAquiError ? err.message : "Erro desconhecido"}`,
       isInternal: true,
-      deliveryStatus: "FAILED",
-    }).catch(() => {});
-
-    logger.error(
-      { error: err instanceof ReclameAquiError ? { code: err.code, message: err.message } : String(err) },
-      `[reclameaqui-outbound] Failed to request evaluation for ticket ${ticket.id}`
-    );
-    throw err;
+    });
   }
 }
 
 async function handleRequestModeration(
+  job: Job,
   ticketId: string,
   reason: number,
   message: string,
@@ -420,7 +607,7 @@ async function handleRequestModeration(
   filePaths?: string[],
   filesBase64?: string[]
 ): Promise<void> {
-  const { ticket, raExternalId, client } = await getTicketWithRaChannel(ticketId);
+  const { ticket, raExternalId, client, companyId } = await getTicketWithRaChannel(ticketId);
 
   try {
     await client.authenticate();
@@ -442,26 +629,22 @@ async function handleRequestModeration(
 
     logger.info(`[reclameaqui-outbound] Moderation requested for ticket ${ticket.id}, reason: ${reason}`);
   } catch (err) {
-    await createOutboundMessage({
+    await handleOutboundError({
+      err,
+      job,
       ticketId: ticket.id,
+      companyId,
       content: `[Sistema] Falha ao solicitar moderação: ${err instanceof ReclameAquiError ? err.message : "Erro desconhecido"}`,
       isInternal: true,
-      deliveryStatus: "FAILED",
-    }).catch(() => {});
-
-    logger.error(
-      { error: err instanceof ReclameAquiError ? { code: err.code, message: err.message } : String(err) },
-      `[reclameaqui-outbound] Failed to request moderation for ticket ${ticket.id}`
-    );
-    throw err;
+    });
   } finally {
     // Always cleanup disk files, even on failure
     await cleanupFiles(filePaths);
   }
 }
 
-async function handleFinishPrivate(ticketId: string): Promise<void> {
-  const { ticket, raExternalId, client } = await getTicketWithRaChannel(ticketId);
+async function handleFinishPrivate(job: Job, ticketId: string): Promise<void> {
+  const { ticket, raExternalId, client, companyId } = await getTicketWithRaChannel(ticketId);
 
   try {
     await client.authenticate();
@@ -476,29 +659,22 @@ async function handleFinishPrivate(ticketId: string): Promise<void> {
 
     logger.info(`[reclameaqui-outbound] Private messaging finished for ticket ${ticket.id}`);
   } catch (err) {
-    if (isDuplicateError(err)) {
-      await createOutboundMessage({
-        ticketId: ticket.id,
-        content: "[Sistema] Mensagem privada encerrada (já encerrada anteriormente)",
-        isInternal: true,
-        deliveryStatus: "SENT",
-      });
-      logger.warn(`[reclameaqui-outbound] Duplicate finish private for ticket ${ticket.id}, marked as SENT`);
-      return;
-    }
-
-    await createOutboundMessage({
+    await handleOutboundError({
+      err,
+      job,
       ticketId: ticket.id,
+      companyId,
       content: `[Sistema] Falha ao encerrar mensagem privada: ${err instanceof ReclameAquiError ? err.message : "Erro desconhecido"}`,
       isInternal: true,
-      deliveryStatus: "FAILED",
-    }).catch(() => {});
-
-    logger.error(
-      { error: err instanceof ReclameAquiError ? { code: err.code, message: err.message } : String(err) },
-      `[reclameaqui-outbound] Failed to finish private messaging for ticket ${ticket.id}`
-    );
-    throw err;
+      onDuplicate: async () => {
+        await createOutboundMessage({
+          ticketId: ticket.id,
+          content: "[Sistema] Mensagem privada encerrada (já encerrada anteriormente)",
+          isInternal: true,
+          deliveryStatus: "SENT",
+        });
+      },
+    });
   }
 }
 
@@ -511,25 +687,41 @@ export async function processReclameAquiOutbound(job: Job<RaOutboundJobData>): P
   const jobType = job.name;
   const startTime = Date.now();
 
-  logger.info(`[reclameaqui-outbound] Processing job ${job.id}: type=${jobType}, ticketId=${data.ticketId}`);
+  logger.info(
+    { jobType, ticketId: data.ticketId, attempt: job.attemptsMade + 1, maxAttempts: job.opts?.attempts ?? 3 },
+    `[reclameaqui-outbound] Processing job ${job.id}: type=${jobType}, ticketId=${data.ticketId}, attempt=${job.attemptsMade + 1}`
+  );
+
+export async function processReclameAquiOutbound(job: Job<RaOutboundJobData>): Promise<void> {
+  const data = job.data;
+  const jobType = job.name;
+  const startTime = Date.now();
+
+  logger.info(
+    { jobType, ticketId: data.ticketId, attempt: job.attemptsMade + 1, maxAttempts: job.opts?.attempts ?? 3 },
+    `[reclameaqui-outbound] Processing job ${job.id}: type=${jobType}, ticketId=${data.ticketId}, attempt=${job.attemptsMade + 1}`
+  );
 
   try {
     switch (jobType) {
       case "RA_SEND_PUBLIC":
-        await handleSendPublic(data.ticketId, (data as RaSendPublicJobData).message);
+        await handleSendPublic(job, data.ticketId, (data as RaSendPublicJobData).message);
         break;
 
-    case "RA_SEND_PRIVATE":
-      return handleSendPrivate(
-        data.ticketId,
-        (data as RaSendPrivateJobData).message,
-        (data as RaSendPrivateJobData).email,
-        (data as RaSendPrivateJobData).filePaths,
-        (data as RaSendPrivateJobData).files
-      );
+      case "RA_SEND_PRIVATE":
+        await handleSendPrivate(
+          job,
+          data.ticketId,
+          (data as RaSendPrivateJobData).message,
+          (data as RaSendPrivateJobData).email,
+          (data as RaSendPrivateJobData).filePaths,
+          (data as RaSendPrivateJobData).files
+        );
+        break;
 
       case "RA_SEND_DUAL":
         await handleSendDual(
+          job,
           data.ticketId,
           (data as RaSendDualJobData).privateMessage,
           (data as RaSendDualJobData).publicMessage,
@@ -538,21 +730,23 @@ export async function processReclameAquiOutbound(job: Job<RaOutboundJobData>): P
         break;
 
       case "RA_REQUEST_EVALUATION":
-        await handleRequestEvaluation(data.ticketId);
+        await handleRequestEvaluation(job, data.ticketId);
         break;
 
-    case "RA_REQUEST_MODERATION":
-      return handleRequestModeration(
-        data.ticketId,
-        (data as RaRequestModerationJobData).reason,
-        (data as RaRequestModerationJobData).message,
-        (data as RaRequestModerationJobData).migrateTO,
-        (data as RaRequestModerationJobData).filePaths,
-        (data as RaRequestModerationJobData).files
-      );
+      case "RA_REQUEST_MODERATION":
+        await handleRequestModeration(
+          job,
+          data.ticketId,
+          (data as RaRequestModerationJobData).reason,
+          (data as RaRequestModerationJobData).message,
+          (data as RaRequestModerationJobData).migrateTO,
+          (data as RaRequestModerationJobData).filePaths,
+          (data as RaRequestModerationJobData).files
+        );
+        break;
 
       case "RA_FINISH_PRIVATE":
-        await handleFinishPrivate(data.ticketId);
+        await handleFinishPrivate(job, data.ticketId);
         break;
 
       default:


### PR DESCRIPTION
S1 — Retry com Backoff no Outbound Worker

- Retry 3x com backoff exponencial (5s/10s/20s) em todos os jobs outbound
- Classificação de erros: retriable (4290/5000/5030) vs permanente (4090/4095/40917)
- Mensagem FAILED visível na timeline com botão 'Tentar novamente'
- Log estruturado com jobType, ticketId, attempt, error, willRetry
- 25 testes

PRD: dev/erp/prd-sac-ra-hardening.md