### PR TITLE
feat(sac): polling inteligente count-first RA

### DIFF
--- a/erp/src/lib/workers/__tests__/reclameaqui-inbound-polling.test.ts
+++ b/erp/src/lib/workers/__tests__/reclameaqui-inbound-polling.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+
+const mockChannelFindMany = vi.fn();
+const mockChannelUpdate = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    channel: {
+      findMany: (...args: unknown[]) => mockChannelFindMany(...args),
+      update: (...args: unknown[]) => mockChannelUpdate(...args),
+    },
+    ticket: {
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
+    client: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: "client-1" }),
+      findUnique: vi.fn().mockResolvedValue({ name: "Test Client" }),
+    },
+    attachment: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({}),
+    },
+    ticketMessage: {
+      create: vi.fn().mockResolvedValue({ id: "msg-1" }),
+    },
+    $transaction: vi.fn().mockImplementation((fn: any) =>
+      fn({
+        client: {
+          findFirst: vi.fn().mockResolvedValue(null),
+          create: vi.fn().mockResolvedValue({ id: "client-1" }),
+        },
+        ticket: {
+          create: vi.fn().mockResolvedValue({ id: "ticket-1" }),
+        },
+        attachment: {
+          findFirst: vi.fn().mockResolvedValue(null),
+          create: vi.fn().mockResolvedValue({}),
+        },
+        ticketMessage: {
+          create: vi.fn().mockResolvedValue({ id: "msg-1" }),
+        },
+      })
+    ),
+  },
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  decryptConfig: (config: unknown) => config,
+}));
+
+vi.mock("@/lib/queue", () => ({
+  aiAgentQueue: { add: vi.fn() },
+}));
+
+// Use a class-based mock for ReclameAquiClient to support `new`
+const mockAuthenticate = vi.fn().mockResolvedValue({});
+const mockCheckTicketAvailability = vi.fn().mockResolvedValue(true);
+const mockCountTickets = vi.fn();
+const mockGetTickets = vi.fn();
+
+vi.mock("@/lib/reclameaqui/client", () => {
+  const MockReclameAquiClient = vi.fn(function (this: any) {
+    this.authenticate = mockAuthenticate;
+    this.checkTicketAvailability = mockCheckTicketAvailability;
+    this.countTickets = mockCountTickets;
+    this.getTickets = mockGetTickets;
+  });
+
+  return {
+    ReclameAquiClient: MockReclameAquiClient,
+    ReclameAquiError: class extends Error {
+      code: number;
+      httpStatus: number;
+      originalMessage: string;
+      constructor(msg: string, code: number, httpStatus: number, orig: string) {
+        super(msg);
+        this.code = code;
+        this.httpStatus = httpStatus;
+        this.originalMessage = orig;
+      }
+    },
+  };
+});
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { processReclameAquiInbound } from "../reclameaqui-inbound";
+import { logger } from "@/lib/logger";
+import type { Job } from "bullmq";
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+const makeChannel = (overrides?: Partial<{
+  id: string;
+  companyId: string;
+  lastSyncAt: Date | null;
+  config: Record<string, unknown>;
+}>) => ({
+  id: "ch-1",
+  companyId: "comp-1",
+  lastSyncAt: new Date("2026-03-27T10:00:00Z"),
+  config: {
+    clientId: "test-client",
+    clientSecret: "test-secret",
+    baseUrl: "https://app.hugme.com.br/api",
+    lastSyncDate: "2026-03-27T10:00:00.000Z",
+  },
+  ...overrides,
+});
+
+const fakeJob = {} as Job;
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe("reclameaqui-inbound count-first polling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChannelUpdate.mockResolvedValue({});
+    mockAuthenticate.mockResolvedValue({});
+    mockCheckTicketAvailability.mockResolvedValue(true);
+  });
+
+  it("skips full sync when countTickets returns 0", async () => {
+    mockChannelFindMany.mockResolvedValue([makeChannel()]);
+    mockCountTickets.mockResolvedValue({ data: 0 });
+
+    await processReclameAquiInbound(fakeJob);
+
+    // Count was called
+    expect(mockCountTickets).toHaveBeenCalledTimes(1);
+    expect(mockCountTickets).toHaveBeenCalledWith({
+      last_modification_date: {
+        comparator: "gte",
+        value: "2026-03-27T10:00:00.000Z",
+      },
+    });
+
+    // getTickets was NOT called (skipped)
+    expect(mockGetTickets).not.toHaveBeenCalled();
+
+    // lastSyncAt was still updated
+    expect(mockChannelUpdate).toHaveBeenCalledTimes(1);
+    expect(mockChannelUpdate.mock.calls[0][0].data.lastSyncAt).toBeInstanceOf(Date);
+
+    // Informative skip log
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("No changes since")
+    );
+  });
+
+  it("proceeds with full sync when countTickets returns > 0", async () => {
+    mockChannelFindMany.mockResolvedValue([makeChannel()]);
+    mockCountTickets.mockResolvedValue({ data: 3 });
+    mockGetTickets.mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: { number: 1, size: 50 } },
+    });
+
+    await processReclameAquiInbound(fakeJob);
+
+    expect(mockCountTickets).toHaveBeenCalledTimes(1);
+    expect(mockGetTickets).toHaveBeenCalledTimes(1);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("3 ticket(s) modified since")
+    );
+  });
+
+  it("uses DB lastSyncAt over config.lastSyncDate", async () => {
+    const dbDate = new Date("2026-03-28T00:00:00Z");
+    mockChannelFindMany.mockResolvedValue([
+      makeChannel({
+        lastSyncAt: dbDate,
+        config: {
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          baseUrl: "https://app.hugme.com.br/api",
+          lastSyncDate: "2026-03-20T00:00:00.000Z", // older config date
+        },
+      }),
+    ]);
+    mockCountTickets.mockResolvedValue({ data: 0 });
+
+    await processReclameAquiInbound(fakeJob);
+
+    // Should use DB date (newer), not config date
+    expect(mockCountTickets).toHaveBeenCalledWith({
+      last_modification_date: {
+        comparator: "gte",
+        value: dbDate.toISOString(),
+      },
+    });
+  });
+
+  it("falls back to config.lastSyncDate when DB lastSyncAt is null", async () => {
+    mockChannelFindMany.mockResolvedValue([
+      makeChannel({ lastSyncAt: null }),
+    ]);
+    mockCountTickets.mockResolvedValue({ data: 0 });
+
+    await processReclameAquiInbound(fakeJob);
+
+    expect(mockCountTickets).toHaveBeenCalledWith({
+      last_modification_date: {
+        comparator: "gte",
+        value: "2026-03-27T10:00:00.000Z",
+      },
+    });
+  });
+
+  it("falls back to 7 days ago when both DB and config are empty", async () => {
+    mockChannelFindMany.mockResolvedValue([
+      makeChannel({
+        lastSyncAt: null,
+        config: {
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          baseUrl: "https://app.hugme.com.br/api",
+        },
+      }),
+    ]);
+    mockCountTickets.mockResolvedValue({ data: 0 });
+
+    await processReclameAquiInbound(fakeJob);
+
+    // Should be ~7 days ago
+    const callArg = mockCountTickets.mock.calls[0][0];
+    const syncDate = new Date(callArg.last_modification_date.value);
+    const daysDiff = (Date.now() - syncDate.getTime()) / (1000 * 60 * 60 * 24);
+    expect(daysDiff).toBeGreaterThan(6.9);
+    expect(daysDiff).toBeLessThan(7.1);
+  });
+
+  it("skips channel when API is unavailable", async () => {
+    mockChannelFindMany.mockResolvedValue([makeChannel()]);
+    mockCheckTicketAvailability.mockResolvedValue(false);
+
+    await processReclameAquiInbound(fakeJob);
+
+    expect(mockCountTickets).not.toHaveBeenCalled();
+    expect(mockGetTickets).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Ticket API indisponível")
+    );
+  });
+
+  it("handles no active channels gracefully", async () => {
+    mockChannelFindMany.mockResolvedValue([]);
+
+    await processReclameAquiInbound(fakeJob);
+
+    expect(mockCountTickets).not.toHaveBeenCalled();
+    expect(mockGetTickets).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("No active RECLAMEAQUI channels found")
+    );
+  });
+
+  it("rate limit respected: count = 1 call, sync = N paginated calls", async () => {
+    mockChannelFindMany.mockResolvedValue([makeChannel()]);
+    mockCountTickets.mockResolvedValue({ data: 60 });
+
+    const makeTicket = (extId: string) => ({
+      source_external_id: extId,
+      ra_status: { id: 5, name: "Não respondido" },
+      customer: { name: "Test", email: [], cpf: [], phone_numbers: [] },
+      complaint_title: "Test",
+      complaint_content: "Test",
+      complaint_response_content: null,
+      creation_date: "2026-03-28T00:00:00Z",
+      last_modification_date: "2026-03-28T00:00:00Z",
+      company: { companyId: 1, name: "Test" },
+      hugme_status: { id: 1, name: "Pendente" },
+      request_evaluation: false,
+      request_moderation: false,
+      resolved_issue: null,
+      back_doing_business: null,
+      rating: null,
+      interactions: [],
+      moderation: null,
+      ra_reason: null,
+      ra_feeling: null,
+      categories: [],
+      consumer_consideration: null,
+      consumer_consideration_date: null,
+      company_consideration: null,
+      company_consideration_date: null,
+      public_treatment_time: null,
+      private_treatment_time: null,
+      rating_date: null,
+      comments_count: 0,
+      interactions_not_readed_count: 0,
+      whatsapp: null,
+      active: true,
+      frozen: false,
+    });
+
+    // Simulate 2 pages of results
+    mockGetTickets
+      .mockResolvedValueOnce({
+        data: Array(50).fill(makeTicket("ext-1")),
+        meta: { total: 60, page: { number: 1, size: 50 } },
+      })
+      .mockResolvedValueOnce({
+        data: Array(10).fill(makeTicket("ext-2")),
+        meta: { total: 60, page: { number: 2, size: 50 } },
+      });
+
+    await processReclameAquiInbound(fakeJob);
+
+    // 1 count call + 2 paginated calls
+    expect(mockCountTickets).toHaveBeenCalledTimes(1);
+    expect(mockGetTickets).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── Unit tests for exported helpers ───────────────────────────────────────
+
+describe("resolveLastSyncDate", () => {
+  let resolveLastSyncDate: (dbLastSyncAt: Date | null, configLastSyncDate?: string) => string;
+
+  beforeEach(async () => {
+    const mod = await import("../reclameaqui-inbound");
+    resolveLastSyncDate = (mod as any)._resolveLastSyncDate;
+  });
+
+  it("returns DB date when available", () => {
+    const dbDate = new Date("2026-03-28T12:00:00Z");
+    expect(resolveLastSyncDate(dbDate, "2026-03-20T00:00:00Z")).toBe(dbDate.toISOString());
+  });
+
+  it("returns config date when DB is null", () => {
+    expect(resolveLastSyncDate(null, "2026-03-20T00:00:00Z")).toBe("2026-03-20T00:00:00Z");
+  });
+
+  it("returns 7 days ago when both are empty", () => {
+    const result = resolveLastSyncDate(null);
+    const date = new Date(result);
+    const daysDiff = (Date.now() - date.getTime()) / (1000 * 60 * 60 * 24);
+    expect(daysDiff).toBeGreaterThan(6.9);
+    expect(daysDiff).toBeLessThan(7.1);
+  });
+});
+
+describe("countModifiedTickets", () => {
+  it("returns the count from API response", async () => {
+    const mod = await import("../reclameaqui-inbound");
+    const countModifiedTickets = (mod as any)._countModifiedTickets;
+
+    const mockClient = {
+      countTickets: vi.fn().mockResolvedValue({ data: 42 }),
+    };
+
+    const result = await countModifiedTickets(mockClient, "2026-03-27T00:00:00Z");
+    expect(result).toBe(42);
+    expect(mockClient.countTickets).toHaveBeenCalledWith({
+      last_modification_date: {
+        comparator: "gte",
+        value: "2026-03-27T00:00:00Z",
+      },
+    });
+  });
+
+  it("returns 0 when API returns undefined data", async () => {
+    const mod = await import("../reclameaqui-inbound");
+    const countModifiedTickets = (mod as any)._countModifiedTickets;
+
+    const mockClient = {
+      countTickets: vi.fn().mockResolvedValue({}),
+    };
+
+    const result = await countModifiedTickets(mockClient, "2026-03-27T00:00:00Z");
+    expect(result).toBe(0);
+  });
+});

--- a/erp/src/lib/workers/reclameaqui-inbound.ts
+++ b/erp/src/lib/workers/reclameaqui-inbound.ts
@@ -29,6 +29,7 @@ interface SyncSummary {
   created: number;
   updated: number;
   errors: number;
+  skippedByCount: boolean;
 }
 
 /** Prisma transaction client type */
@@ -102,6 +103,18 @@ function defaultSyncDate(): string {
   const d = new Date();
   d.setDate(d.getDate() - 7);
   return d.toISOString();
+}
+
+/**
+ * Resolve the last sync date for a channel.
+ * Priority: DB lastSyncAt > config.lastSyncDate > 7 days ago.
+ */
+function resolveLastSyncDate(
+  dbLastSyncAt: Date | null,
+  configLastSyncDate?: string
+): string {
+  if (dbLastSyncAt) return dbLastSyncAt.toISOString();
+  return configLastSyncDate || defaultSyncDate();
 }
 
 /**
@@ -572,6 +585,31 @@ async function createTicketMessage(
 }
 
 // ---------------------------------------------------------------------------
+// Count-First Check
+// ---------------------------------------------------------------------------
+
+/**
+ * Performs a lightweight count check before full sync.
+ * Returns the number of tickets modified since lastSyncDate.
+ * Uses 1 API call instead of potentially many paginated GETs.
+ *
+ * With count-first, the cron interval can safely go from 15min → 5min
+ * since most executions will only cost 1 API call (auth + count).
+ */
+async function countModifiedTickets(
+  client: ReclameAquiClient,
+  lastSyncDate: string
+): Promise<number> {
+  const countResponse = await client.countTickets({
+    last_modification_date: {
+      comparator: "gte",
+      value: lastSyncDate,
+    },
+  });
+  return countResponse.data ?? 0;
+}
+
+// ---------------------------------------------------------------------------
 // Main Processor
 // ---------------------------------------------------------------------------
 
@@ -580,7 +618,7 @@ export async function processReclameAquiInbound(_job: Job): Promise<void> {
   // Find all active RECLAMEAQUI channels
   const channels = await prisma.channel.findMany({
     where: { type: "RECLAMEAQUI", isActive: true },
-    select: { id: true, companyId: true, config: true },
+    select: { id: true, companyId: true, config: true, lastSyncAt: true },
   });
 
   if (channels.length === 0) {
@@ -589,7 +627,7 @@ export async function processReclameAquiInbound(_job: Job): Promise<void> {
   }
 
   for (const ch of channels) {
-    const summary: SyncSummary = { total: 0, created: 0, updated: 0, errors: 0 };
+    const summary: SyncSummary = { total: 0, created: 0, updated: 0, errors: 0, skippedByCount: false };
 
     let config: ReclameAquiChannelConfig;
     try {
@@ -623,13 +661,44 @@ export async function processReclameAquiInbound(_job: Job): Promise<void> {
       continue;
     }
 
-    const lastSyncDate = config.lastSyncDate || defaultSyncDate();
+    // Resolve last sync date: DB field > config > 7 days ago
+    const lastSyncDate = resolveLastSyncDate(ch.lastSyncAt, config.lastSyncDate);
 
     try {
       // Authenticate
       await client.authenticate();
 
-      // Paginate through all tickets modified since last sync
+      // ── Count-first check ──────────────────────────────────────
+      // Before paginating, check if anything changed since last sync.
+      // Costs 1 API call. If count = 0, skip full sync entirely.
+      const modifiedCount = await countModifiedTickets(client, lastSyncDate);
+
+      if (modifiedCount === 0) {
+        logger.info(
+          `[reclameaqui-inbound] No changes since ${lastSyncDate} for channel ${ch.id}, skipping sync`
+        );
+        summary.skippedByCount = true;
+
+        // Still update lastSyncAt to advance the window
+        const now = new Date();
+        await prisma.channel.update({
+          where: { id: ch.id },
+          data: {
+            lastSyncAt: now,
+            config: {
+              ...(ch.config as Record<string, unknown>),
+              lastSyncDate: now.toISOString(),
+            },
+          },
+        });
+        continue;
+      }
+
+      logger.info(
+        `[reclameaqui-inbound] ${modifiedCount} ticket(s) modified since ${lastSyncDate} for channel ${ch.id}, starting sync`
+      );
+
+      // ── Full sync (only when count > 0) ────────────────────────
       let pageNumber = 1;
       let hasMore = true;
 
@@ -693,3 +762,14 @@ export async function processReclameAquiInbound(_job: Job): Promise<void> {
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// Exported for testing
+// ---------------------------------------------------------------------------
+
+export {
+  countModifiedTickets as _countModifiedTickets,
+  resolveLastSyncDate as _resolveLastSyncDate,
+  mapRaStatusToTicketStatus as _mapRaStatusToTicketStatus,
+  mapInteractionDirection as _mapInteractionDirection,
+};


### PR DESCRIPTION
S4 — Polling Inteligente (Count-First)

- Count-first check antes do sync completo
- Se count=0, skip (1 API call vs N)
- Usa lastSyncAt do Channel (já existia no schema)
- Fallback: config → 7 dias atrás
- Rate limit reduzido significativamente
- 13 testes

PRD: dev/erp/prd-sac-ra-hardening.md