### PR TITLE
feat(sac): upload via disco (não base64) RA

### DIFF
--- a/erp/src/app/(app)/sac/tickets/ra-actions.ts
+++ b/erp/src/app/(app)/sac/tickets/ra-actions.ts
@@ -11,6 +11,8 @@ import { RA_ERROR_MESSAGES } from "@/lib/reclameaqui/errors";
 import { RA_ATTACHMENT_LIMITS } from "@/lib/reclameaqui/attachments";
 import { Prisma } from "@prisma/client";
 import { logger } from "@/lib/logger";
+import { promises as fs } from "fs";
+import crypto from "crypto";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -764,6 +766,32 @@ export async function finishPrivateMessage(
 }
 
 // ---------------------------------------------------------------------------
+// Helper: save FormData files to disk, return paths
+// ---------------------------------------------------------------------------
+
+async function saveFilesToDisk(
+  ticketId: string,
+  formData: FormData
+): Promise<string[]> {
+  const tempDir = `/tmp/ra-uploads/${ticketId}`;
+  await fs.mkdir(tempDir, { recursive: true });
+
+  const filePaths: string[] = [];
+  const entries = formData.getAll("files");
+  for (const entry of entries) {
+    if (entry instanceof File) {
+      const ext = entry.name.split(".").pop() ?? "";
+      const safeName = `${crypto.randomUUID()}${ext ? `.${ext}` : ""}`;
+      const filePath = `${tempDir}/${safeName}`;
+      await fs.writeFile(filePath, Buffer.from(await entry.arrayBuffer()));
+      filePaths.push(filePath);
+    }
+  }
+
+  return filePaths;
+}
+
+// ---------------------------------------------------------------------------
 // 8. sendPrivateMessageWithAttachments
 // ---------------------------------------------------------------------------
 
@@ -790,18 +818,6 @@ export async function sendPrivateMessageWithAttachments(
       return { success: false, error: "Ticket inválido para Reclame Aqui" };
     }
 
-    // Extract files from FormData
-    const filesBase64: string[] = [];
-    if (formData) {
-      const entries = formData.getAll("files");
-      for (const entry of entries) {
-        if (entry instanceof File) {
-          const buffer = Buffer.from(await entry.arrayBuffer());
-          filesBase64.push(buffer.toString("base64"));
-        }
-      }
-    }
-
     // Server-side validation
     if (formData) {
       const rawFiles = formData.getAll("files");
@@ -823,14 +839,20 @@ export async function sendPrivateMessageWithAttachments(
       }
     }
 
-    // Enqueue with file buffers serialized as base64
+    // Save files to disk instead of base64 to avoid bloating Redis payloads
+    let filePaths: string[] = [];
+    if (formData) {
+      filePaths = await saveFilesToDisk(ticket.id, formData);
+    }
+
+    // Enqueue with file paths only (lightweight payload)
     await reclameaquiOutboundQueue.add("RA_SEND_PRIVATE", {
       ticketId: ticket.id,
       raExternalId: ticket.raExternalId,
       message,
       companyId,
       email: ticket.client.email,
-      files: filesBase64.length > 0 ? filesBase64 : undefined,
+      filePaths: filePaths.length > 0 ? filePaths : undefined,
     });
 
     await logAuditEvent({
@@ -840,7 +862,7 @@ export async function sendPrivateMessageWithAttachments(
       entityId: ticketId,
       dataAfter: {
         action: "SEND_PRIVATE_WITH_ATTACHMENTS",
-        attachmentCount: filesBase64.length,
+        attachmentCount: filePaths.length,
         raExternalId: ticket.raExternalId,
       } as unknown as Prisma.InputJsonValue,
       companyId,
@@ -900,16 +922,10 @@ export async function requestModerationWithAttachments(
       return { success: false, error: "Este ticket não pertence ao canal Reclame Aqui" };
     }
 
-    // Extract files from FormData
-    const filesBase64: string[] = [];
+    // Save files to disk instead of base64 to avoid bloating Redis payloads
+    let filePaths: string[] = [];
     if (formData) {
-      const entries = formData.getAll("files");
-      for (const entry of entries) {
-        if (entry instanceof File) {
-          const buffer = Buffer.from(await entry.arrayBuffer());
-          filesBase64.push(buffer.toString("base64"));
-        }
-      }
+      filePaths = await saveFilesToDisk(ticketId, formData);
     }
 
     await reclameaquiOutboundQueue.add("RA_REQUEST_MODERATION", {
@@ -919,7 +935,7 @@ export async function requestModerationWithAttachments(
       reason,
       message: message.trim(),
       migrateTO,
-      files: filesBase64.length > 0 ? filesBase64 : undefined,
+      filePaths: filePaths.length > 0 ? filePaths : undefined,
     });
 
     await logAuditEvent({
@@ -930,7 +946,7 @@ export async function requestModerationWithAttachments(
       dataAfter: {
         action: "REQUEST_RA_MODERATION_WITH_ATTACHMENTS",
         reason,
-        attachmentCount: filesBase64.length,
+        attachmentCount: filePaths.length,
         raExternalId: ticket.raExternalId,
         migrateTO,
       } as unknown as Prisma.InputJsonValue,

--- a/erp/src/lib/workers/__tests__/reclameaqui-outbound-disk.test.ts
+++ b/erp/src/lib/workers/__tests__/reclameaqui-outbound-disk.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "fs";
+import path from "path";
+import crypto from "crypto";
+
+// ---------------------------------------------------------------------------
+// Mock prisma
+// ---------------------------------------------------------------------------
+
+const mockFindUnique = vi.fn();
+const mockFindFirst = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    ticket: { findUnique: (...a: unknown[]) => mockFindUnique(...a), update: (...a: unknown[]) => mockUpdate(...a) },
+    ticketMessage: { create: (...a: unknown[]) => mockCreate(...a), findFirst: (...a: unknown[]) => mockFindFirst(...a) },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock encryption
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/encryption", () => ({
+  decryptConfig: (c: unknown) => c,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock RA Client
+// ---------------------------------------------------------------------------
+
+const mockAuthenticate = vi.fn();
+const mockSendPrivateMessage = vi.fn();
+const mockRequestModeration = vi.fn();
+
+vi.mock("@/lib/reclameaqui/client", () => {
+  class MockReclameAquiClient {
+    constructor(_config: unknown) {}
+    authenticate = mockAuthenticate;
+    sendPrivateMessage = mockSendPrivateMessage;
+    sendPublicMessage = vi.fn();
+    requestModeration = mockRequestModeration;
+    requestEvaluation = vi.fn();
+    finishPrivateMessage = vi.fn();
+  }
+  class MockReclameAquiError extends Error {
+    code: number;
+    constructor(msg: string, code: number) {
+      super(msg);
+      this.code = code;
+    }
+  }
+  return {
+    ReclameAquiClient: MockReclameAquiClient,
+    ReclameAquiError: MockReclameAquiError,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { processReclameAquiOutbound } from "../reclameaqui-outbound";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEMP_DIR = `/tmp/ra-uploads-test-${crypto.randomUUID()}`;
+
+function fakeTicket(overrides = {}) {
+  return {
+    id: "ticket-1",
+    raExternalId: "ra-ext-1",
+    channel: {
+      id: "ch-1",
+      type: "RECLAMEAQUI",
+      isActive: true,
+      config: { clientId: "cid", clientSecret: "cs", baseUrl: "https://ra.test" },
+    },
+    raCanEvaluate: true,
+    raCanModerate: true,
+    ...overrides,
+  };
+}
+
+function fakeJob(name: string, data: Record<string, unknown>) {
+  return { id: "job-1", name, data } as any;
+}
+
+async function writeTempFile(ticketId: string, filename: string, content: string): Promise<string> {
+  const dir = path.join(TEMP_DIR, ticketId);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, filename);
+  await fs.writeFile(filePath, content);
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("reclameaqui-outbound disk upload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindUnique.mockResolvedValue(fakeTicket());
+    mockCreate.mockResolvedValue({ id: "msg-1" });
+    mockUpdate.mockResolvedValue({});
+  });
+
+  afterEach(async () => {
+    // Cleanup temp dir
+    await fs.rm(TEMP_DIR, { recursive: true, force: true }).catch(() => {});
+  });
+
+  // -------------------------------------------------------------------------
+  // RA_SEND_PRIVATE with filePaths (new format)
+  // -------------------------------------------------------------------------
+
+  it("should read files from disk, send, and cleanup", async () => {
+    const fp1 = await writeTempFile("ticket-1", "file1.pdf", "pdf-content-1");
+    const fp2 = await writeTempFile("ticket-1", "file2.jpg", "jpg-content-2");
+
+    await processReclameAquiOutbound(
+      fakeJob("RA_SEND_PRIVATE", {
+        ticketId: "ticket-1",
+        message: "Hello",
+        email: "test@test.com",
+        filePaths: [fp1, fp2],
+      })
+    );
+
+    // Verify authenticate was called
+    expect(mockAuthenticate).toHaveBeenCalledOnce();
+
+    // Verify sendPrivateMessage was called with buffers
+    expect(mockSendPrivateMessage).toHaveBeenCalledOnce();
+    const [raId, msg, email, buffers] = mockSendPrivateMessage.mock.calls[0];
+    expect(raId).toBe("ra-ext-1");
+    expect(msg).toBe("Hello");
+    expect(email).toBe("test@test.com");
+    expect(buffers).toHaveLength(2);
+    expect(buffers![0].toString()).toBe("pdf-content-1");
+    expect(buffers![1].toString()).toBe("jpg-content-2");
+
+    // Verify files were cleaned up
+    await expect(fs.access(fp1)).rejects.toThrow();
+    await expect(fs.access(fp2)).rejects.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // RA_SEND_PRIVATE with base64 files (legacy backward compat)
+  // -------------------------------------------------------------------------
+
+  it("should still handle legacy base64 files", async () => {
+    const b64_1 = Buffer.from("legacy-content-1").toString("base64");
+    const b64_2 = Buffer.from("legacy-content-2").toString("base64");
+
+    await processReclameAquiOutbound(
+      fakeJob("RA_SEND_PRIVATE", {
+        ticketId: "ticket-1",
+        message: "Legacy hello",
+        email: "legacy@test.com",
+        files: [b64_1, b64_2],
+      })
+    );
+
+    expect(mockSendPrivateMessage).toHaveBeenCalledOnce();
+    const [, , , buffers] = mockSendPrivateMessage.mock.calls[0];
+    expect(buffers).toHaveLength(2);
+    expect(buffers![0].toString()).toBe("legacy-content-1");
+    expect(buffers![1].toString()).toBe("legacy-content-2");
+  });
+
+  // -------------------------------------------------------------------------
+  // Cleanup happens even on failure
+  // -------------------------------------------------------------------------
+
+  it("should cleanup files even when send fails", async () => {
+    const fp = await writeTempFile("ticket-1", "file.pdf", "content");
+
+    mockSendPrivateMessage.mockRejectedValueOnce(new Error("API exploded"));
+
+    await expect(
+      processReclameAquiOutbound(
+        fakeJob("RA_SEND_PRIVATE", {
+          ticketId: "ticket-1",
+          message: "Will fail",
+          email: "test@test.com",
+          filePaths: [fp],
+        })
+      )
+    ).rejects.toThrow("API exploded");
+
+    // File should still be cleaned up
+    await expect(fs.access(fp)).rejects.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // RA_SEND_PRIVATE without files
+  // -------------------------------------------------------------------------
+
+  it("should handle private message without files", async () => {
+    await processReclameAquiOutbound(
+      fakeJob("RA_SEND_PRIVATE", {
+        ticketId: "ticket-1",
+        message: "No files",
+        email: "test@test.com",
+      })
+    );
+
+    expect(mockSendPrivateMessage).toHaveBeenCalledOnce();
+    const [, , , buffers] = mockSendPrivateMessage.mock.calls[0];
+    expect(buffers).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // RA_REQUEST_MODERATION with filePaths
+  // -------------------------------------------------------------------------
+
+  it("should read moderation files from disk and cleanup", async () => {
+    const fp = await writeTempFile("ticket-1", "evidence.pdf", "evidence-data");
+
+    await processReclameAquiOutbound(
+      fakeJob("RA_REQUEST_MODERATION", {
+        ticketId: "ticket-1",
+        reason: 4,
+        message: "Duplicate complaint",
+        filePaths: [fp],
+      })
+    );
+
+    expect(mockRequestModeration).toHaveBeenCalledOnce();
+    const [, , , , buffers] = mockRequestModeration.mock.calls[0];
+    expect(buffers).toHaveLength(1);
+    expect(buffers![0].toString()).toBe("evidence-data");
+
+    // File cleaned up
+    await expect(fs.access(fp)).rejects.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // RA_REQUEST_MODERATION cleanup on failure
+  // -------------------------------------------------------------------------
+
+  it("should cleanup moderation files even on failure", async () => {
+    const fp = await writeTempFile("ticket-1", "evidence.pdf", "evidence-data");
+
+    mockRequestModeration.mockRejectedValueOnce(new Error("Mod failed"));
+
+    await expect(
+      processReclameAquiOutbound(
+        fakeJob("RA_REQUEST_MODERATION", {
+          ticketId: "ticket-1",
+          reason: 4,
+          message: "Duplicate",
+          filePaths: [fp],
+        })
+      )
+    ).rejects.toThrow("Mod failed");
+
+    await expect(fs.access(fp)).rejects.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // filePaths takes precedence over files
+  // -------------------------------------------------------------------------
+
+  it("should prefer filePaths over legacy files when both present", async () => {
+    const fp = await writeTempFile("ticket-1", "new.pdf", "new-content");
+    const b64 = Buffer.from("old-content").toString("base64");
+
+    await processReclameAquiOutbound(
+      fakeJob("RA_SEND_PRIVATE", {
+        ticketId: "ticket-1",
+        message: "Both formats",
+        email: "test@test.com",
+        filePaths: [fp],
+        files: [b64],
+      })
+    );
+
+    const [, , , buffers] = mockSendPrivateMessage.mock.calls[0];
+    expect(buffers).toHaveLength(1);
+    // Should use disk content, not base64
+    expect(buffers![0].toString()).toBe("new-content");
+  });
+});

--- a/erp/src/lib/workers/reclameaqui-outbound.ts
+++ b/erp/src/lib/workers/reclameaqui-outbound.ts
@@ -5,6 +5,7 @@ import { ReclameAquiClient, ReclameAquiError } from "@/lib/reclameaqui/client";
 import { logger } from "@/lib/logger";
 import type { RaClientConfig } from "@/lib/reclameaqui/types";
 import type { MessageDeliveryStatus } from "@prisma/client";
+import { promises as fs } from "fs";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -19,7 +20,8 @@ export interface RaSendPrivateJobData {
   ticketId: string;
   message: string;
   email: string;
-  files?: string[]; // base64-encoded file buffers
+  filePaths?: string[]; // paths to files saved on disk
+  files?: string[]; // base64-encoded file buffers (legacy, backward compat)
 }
 
 export interface RaSendDualJobData {
@@ -38,7 +40,8 @@ export interface RaRequestModerationJobData {
   reason: number;
   message: string;
   migrateTO?: number;
-  files?: string[]; // base64-encoded file buffers
+  filePaths?: string[]; // paths to files saved on disk
+  files?: string[]; // base64-encoded file buffers (legacy, backward compat)
 }
 
 export interface RaFinishPrivateJobData {
@@ -105,6 +108,37 @@ async function getTicketWithRaChannel(ticketId: string) {
  */
 function isDuplicateError(err: unknown): boolean {
   return err instanceof ReclameAquiError && err.code === 40930;
+}
+
+/**
+ * Reads file buffers from disk paths. Falls back to base64 decoding for legacy jobs.
+ */
+async function resolveFileBuffers(
+  filePaths?: string[],
+  filesBase64?: string[]
+): Promise<Buffer[] | undefined> {
+  // New format: read from disk
+  if (filePaths && filePaths.length > 0) {
+    return Promise.all(filePaths.map((p) => fs.readFile(p)));
+  }
+  // Legacy format: decode base64
+  if (filesBase64 && filesBase64.length > 0) {
+    return filesBase64.map((f) => Buffer.from(f, "base64"));
+  }
+  return undefined;
+}
+
+/**
+ * Cleans up temporary files from disk. Silently ignores missing files.
+ */
+async function cleanupFiles(filePaths?: string[]): Promise<void> {
+  if (!filePaths || filePaths.length === 0) return;
+  await Promise.all(filePaths.map((p) => fs.unlink(p).catch(() => {})));
+  // Try to remove the parent directory if empty
+  if (filePaths.length > 0) {
+    const dir = filePaths[0].substring(0, filePaths[0].lastIndexOf("/"));
+    await fs.rmdir(dir).catch(() => {});
+  }
 }
 
 /**
@@ -181,13 +215,19 @@ async function handleSendPublic(ticketId: string, message: string): Promise<void
   }
 }
 
-async function handleSendPrivate(ticketId: string, message: string, email: string, files?: string[]): Promise<void> {
+async function handleSendPrivate(
+  ticketId: string,
+  message: string,
+  email: string,
+  filePaths?: string[],
+  filesBase64?: string[]
+): Promise<void> {
   const { ticket, raExternalId, client } = await getTicketWithRaChannel(ticketId);
 
   try {
     await client.authenticate();
-    // Decode base64 files if present
-    const fileBuffers = files?.map(f => Buffer.from(f, "base64"));
+    // Read files from disk (new) or decode base64 (legacy backward compat)
+    const fileBuffers = await resolveFileBuffers(filePaths, filesBase64);
     await client.sendPrivateMessage(raExternalId, message, email, fileBuffers);
 
     await createOutboundMessage({
@@ -222,6 +262,9 @@ async function handleSendPrivate(ticketId: string, message: string, email: strin
       `[reclameaqui-outbound] Failed to send private message for ticket ${ticket.id}`
     );
     throw err;
+  } finally {
+    // Always cleanup disk files, even on failure
+    await cleanupFiles(filePaths);
   }
 }
 
@@ -373,13 +416,16 @@ async function handleRequestModeration(
   ticketId: string,
   reason: number,
   message: string,
-  migrateTO?: number
-, files?: string[]): Promise<void> {
+  migrateTO?: number,
+  filePaths?: string[],
+  filesBase64?: string[]
+): Promise<void> {
   const { ticket, raExternalId, client } = await getTicketWithRaChannel(ticketId);
 
   try {
     await client.authenticate();
-    const modFileBuffers = files?.map(f => Buffer.from(f, "base64"));
+    // Read files from disk (new) or decode base64 (legacy backward compat)
+    const modFileBuffers = await resolveFileBuffers(filePaths, filesBase64);
     await client.requestModeration(raExternalId, reason, message, migrateTO, modFileBuffers);
 
     await createOutboundMessage({
@@ -408,6 +454,9 @@ async function handleRequestModeration(
       `[reclameaqui-outbound] Failed to request moderation for ticket ${ticket.id}`
     );
     throw err;
+  } finally {
+    // Always cleanup disk files, even on failure
+    await cleanupFiles(filePaths);
   }
 }
 
@@ -472,6 +521,7 @@ export async function processReclameAquiOutbound(job: Job<RaOutboundJobData>): P
         data.ticketId,
         (data as RaSendPrivateJobData).message,
         (data as RaSendPrivateJobData).email,
+        (data as RaSendPrivateJobData).filePaths,
         (data as RaSendPrivateJobData).files
       );
 
@@ -492,6 +542,7 @@ export async function processReclameAquiOutbound(job: Job<RaOutboundJobData>): P
         (data as RaRequestModerationJobData).reason,
         (data as RaRequestModerationJobData).message,
         (data as RaRequestModerationJobData).migrateTO,
+        (data as RaRequestModerationJobData).filePaths,
         (data as RaRequestModerationJobData).files
       );
 


### PR DESCRIPTION
S6 — Upload via Referência em Disco

- Files salvos em /tmp/ra-uploads/{ticketId}/ com UUID prefix
- Queue recebe apenas paths (payload leve)
- Worker lê do disco, envia, cleanup em try/finally
- Backward compat: jobs antigos com base64 continuam funcionando
- 7 testes

PRD: dev/erp/prd-sac-ra-hardening.md