### PR TITLE
fix(sac): decrypt channel config before building ReclameAquiClient

### DIFF
--- a/erp/src/app/(app)/sac/tickets/ra-actions.ts
+++ b/erp/src/app/(app)/sac/tickets/ra-actions.ts
@@ -13,6 +13,7 @@ import { Prisma } from "@prisma/client";
 import { logger } from "@/lib/logger";
 import { promises as fs } from "fs";
 import crypto from "crypto";
+import { decryptConfig } from "@/lib/encryption";
 
 import type { RaActionResult, RaReputationData, RaReputationResult, RaAvailableAction, RaTicketContext } from "./ra-actions.types";
 
@@ -87,7 +88,7 @@ async function getRaClientForCompany(companyId: string): Promise<{ client: Recla
     throw new Error("Canal Reclame Aqui não configurado para esta empresa");
   }
 
-  const config = channel.config as unknown as RaClientConfig & { companyId?: number };
+  const config = decryptConfig(channel.config as Record<string, unknown>) as unknown as RaClientConfig & { companyId?: number };
 
   if (!config.clientId || !config.clientSecret || !config.baseUrl) {
     throw new Error("Configuração do canal Reclame Aqui incompleta");


### PR DESCRIPTION
## Problema

`getRaClientForCompany()` em `src/app/(app)/sac/tickets/ra-actions.ts` lia `channel.config` do banco e fazia cast direto para `RaClientConfig` **sem descriptografar**.

Config é salva criptografada → `clientId`/`clientSecret` chegavam como cipher-text no `ReclameAquiClient` → autenticação sempre falhava com **Token inválido ou expirado**.

## Causa raiz

```ts
// ANTES (bugado)
const config = channel.config as unknown as RaClientConfig & { companyId?: number };

// DEPOIS (correto)
const config = decryptConfig(channel.config as Record<string, unknown>) as unknown as RaClientConfig & { companyId?: number };
```

## Evidência

Workers (`reclameaqui-inbound.ts`, `reclameaqui-outbound.ts`) e a tela de configurações já usavam `decryptConfig()` corretamente — por isso o *Testar Conexão* funcionava mas as ações de resposta/reputação do SAC falhavam.

## Checklist

- [x] Lint limpo (`eslint` sem warnings)
- [x] TypeCheck sem erros no arquivo alterado (`tsc --noEmit`)
- [x] 1 arquivo modificado, 2 linhas (+import, +decryptConfig)