### PR TITLE
fix: guard against null reputation in RA API response

### DIFF
--- a/erp/src/app/(app)/sac/tickets/ra-actions.ts
+++ b/erp/src/app/(app)/sac/tickets/ra-actions.ts
@@ -648,8 +648,8 @@ export async function getRaReputation(
         finalGrade: r.finalGrade,
         avgGrade: r.avgGrade,
         complaintsCount: r.complaintsCount,
-        reputationCode: r.reputation.code,
-        reputationName: r.reputation.name,
+        reputationCode: r.reputation?.code ?? "SEM_INDICE",
+        reputationName: r.reputation?.name ?? "Sem Índice",
       })),
     };
 


### PR DESCRIPTION
r.reputation pode ser null quando a API do RA retorna períodos sem dados de reputação. Adicionado optional chaining e fallback para SEM_INDICE.