### PR TITLE
fix(actions): re-export server actions as async functions to fix use-server validation

### DIFF
--- a/erp/src/app/(app)/comercial/clientes/[id]/actions.ts
+++ b/erp/src/app/(app)/comercial/clientes/[id]/actions.ts
@@ -245,5 +245,7 @@ async function _getClientTimeline(
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const getClientById = withLogging('clientes.detail.getClientById', _getClientById);
-export const getClientTimeline = withLogging('clientes.detail.getClientTimeline', _getClientTimeline);
+const _wrapped_getClientById = withLogging('clientes.detail.getClientById', _getClientById);
+export async function getClientById(...args: Parameters<typeof _getClientById>) { return _wrapped_getClientById(...args); }
+const _wrapped_getClientTimeline = withLogging('clientes.detail.getClientTimeline', _getClientTimeline);
+export async function getClientTimeline(...args: Parameters<typeof _getClientTimeline>) { return _wrapped_getClientTimeline(...args); }

--- a/erp/src/app/(app)/comercial/clientes/actions.ts
+++ b/erp/src/app/(app)/comercial/clientes/actions.ts
@@ -275,7 +275,11 @@ async function _getClientForEdit(clientId: string, companyId: string) {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const listClients = withLogging('clientes.listClients', _listClients);
-export const createClient = withLogging('clientes.createClient', _createClient);
-export const updateClient = withLogging('clientes.updateClient', _updateClient);
-export const getClientForEdit = withLogging('clientes.getClientForEdit', _getClientForEdit);
+const _wrapped_listClients = withLogging('clientes.listClients', _listClients);
+export async function listClients(...args: Parameters<typeof _listClients>) { return _wrapped_listClients(...args); }
+const _wrapped_createClient = withLogging('clientes.createClient', _createClient);
+export async function createClient(...args: Parameters<typeof _createClient>) { return _wrapped_createClient(...args); }
+const _wrapped_updateClient = withLogging('clientes.updateClient', _updateClient);
+export async function updateClient(...args: Parameters<typeof _updateClient>) { return _wrapped_updateClient(...args); }
+const _wrapped_getClientForEdit = withLogging('clientes.getClientForEdit', _getClientForEdit);
+export async function getClientForEdit(...args: Parameters<typeof _getClientForEdit>) { return _wrapped_getClientForEdit(...args); }

--- a/erp/src/app/(app)/comercial/pipeline/actions.ts
+++ b/erp/src/app/(app)/comercial/pipeline/actions.ts
@@ -187,5 +187,7 @@ async function _listClientsForPipeline(
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const listPipelineData = withLogging('pipeline.listPipelineData', _listPipelineData);
-export const listClientsForPipeline = withLogging('pipeline.listClientsForPipeline', _listClientsForPipeline);
+const _wrapped_listPipelineData = withLogging('pipeline.listPipelineData', _listPipelineData);
+export async function listPipelineData(...args: Parameters<typeof _listPipelineData>) { return _wrapped_listPipelineData(...args); }
+const _wrapped_listClientsForPipeline = withLogging('pipeline.listClientsForPipeline', _listClientsForPipeline);
+export async function listClientsForPipeline(...args: Parameters<typeof _listClientsForPipeline>) { return _wrapped_listClientsForPipeline(...args); }

--- a/erp/src/app/(app)/comercial/propostas/actions.ts
+++ b/erp/src/app/(app)/comercial/propostas/actions.ts
@@ -1154,15 +1154,27 @@ async function _listProposalEvents(
 // ---------------------------------------------------------------------------
 // Wrapped exports with structured logging
 // ---------------------------------------------------------------------------
-export const listProposals = withLogging('comercial.propostas.listProposals', _listProposals);
-export const createProposal = withLogging('comercial.propostas.createProposal', _createProposal);
-export const updateProposal = withLogging('comercial.propostas.updateProposal', _updateProposal);
-export const getProposalById = withLogging('comercial.propostas.getProposalById', _getProposalById);
-export const updateProposalStatus = withLogging('comercial.propostas.updateProposalStatus', _updateProposalStatus);
-export const listClientsForProposal = withLogging('comercial.propostas.listClientsForProposal', _listClientsForProposal);
-export const getProvidersForProposal = withLogging('comercial.propostas.getProvidersForProposal', _getProvidersForProposal);
-export const previewRoutingForProposal = withLogging('comercial.propostas.previewRoutingForProposal', _previewRoutingForProposal);
-export const generateBoletosForProposal = withLogging('comercial.propostas.generateBoletosForProposal', _generateBoletosForProposal);
-export const listBoletosForProposal = withLogging('comercial.propostas.listBoletosForProposal', _listBoletosForProposal);
-export const updateBoletoStatus = withLogging('comercial.propostas.updateBoletoStatus', _updateBoletoStatus);
-export const listProposalEvents = withLogging('comercial.propostas.listProposalEvents', _listProposalEvents);
+const _wrapped_listProposals = withLogging('comercial.propostas.listProposals', _listProposals);
+export async function listProposals(...args: Parameters<typeof _listProposals>) { return _wrapped_listProposals(...args); }
+const _wrapped_createProposal = withLogging('comercial.propostas.createProposal', _createProposal);
+export async function createProposal(...args: Parameters<typeof _createProposal>) { return _wrapped_createProposal(...args); }
+const _wrapped_updateProposal = withLogging('comercial.propostas.updateProposal', _updateProposal);
+export async function updateProposal(...args: Parameters<typeof _updateProposal>) { return _wrapped_updateProposal(...args); }
+const _wrapped_getProposalById = withLogging('comercial.propostas.getProposalById', _getProposalById);
+export async function getProposalById(...args: Parameters<typeof _getProposalById>) { return _wrapped_getProposalById(...args); }
+const _wrapped_updateProposalStatus = withLogging('comercial.propostas.updateProposalStatus', _updateProposalStatus);
+export async function updateProposalStatus(...args: Parameters<typeof _updateProposalStatus>) { return _wrapped_updateProposalStatus(...args); }
+const _wrapped_listClientsForProposal = withLogging('comercial.propostas.listClientsForProposal', _listClientsForProposal);
+export async function listClientsForProposal(...args: Parameters<typeof _listClientsForProposal>) { return _wrapped_listClientsForProposal(...args); }
+const _wrapped_getProvidersForProposal = withLogging('comercial.propostas.getProvidersForProposal', _getProvidersForProposal);
+export async function getProvidersForProposal(...args: Parameters<typeof _getProvidersForProposal>) { return _wrapped_getProvidersForProposal(...args); }
+const _wrapped_previewRoutingForProposal = withLogging('comercial.propostas.previewRoutingForProposal', _previewRoutingForProposal);
+export async function previewRoutingForProposal(...args: Parameters<typeof _previewRoutingForProposal>) { return _wrapped_previewRoutingForProposal(...args); }
+const _wrapped_generateBoletosForProposal = withLogging('comercial.propostas.generateBoletosForProposal', _generateBoletosForProposal);
+export async function generateBoletosForProposal(...args: Parameters<typeof _generateBoletosForProposal>) { return _wrapped_generateBoletosForProposal(...args); }
+const _wrapped_listBoletosForProposal = withLogging('comercial.propostas.listBoletosForProposal', _listBoletosForProposal);
+export async function listBoletosForProposal(...args: Parameters<typeof _listBoletosForProposal>) { return _wrapped_listBoletosForProposal(...args); }
+const _wrapped_updateBoletoStatus = withLogging('comercial.propostas.updateBoletoStatus', _updateBoletoStatus);
+export async function updateBoletoStatus(...args: Parameters<typeof _updateBoletoStatus>) { return _wrapped_updateBoletoStatus(...args); }
+const _wrapped_listProposalEvents = withLogging('comercial.propostas.listProposalEvents', _listProposalEvents);
+export async function listProposalEvents(...args: Parameters<typeof _listProposalEvents>) { return _wrapped_listProposalEvents(...args); }

--- a/erp/src/app/(app)/configuracoes/ai/actions.ts
+++ b/erp/src/app/(app)/configuracoes/ai/actions.ts
@@ -638,11 +638,19 @@ async function _simulateAiResponse(
 // ---------------------------------------------------------------------------
 // Wrapped exports with structured logging
 // ---------------------------------------------------------------------------
-export const getAiConfig = withLogging('configuracoes.ai.getAiConfig', _getAiConfig);
-export const updateAiConfig = withLogging('configuracoes.ai.updateAiConfig', _updateAiConfig);
-export const testAiConnection = withLogging('configuracoes.ai.testAiConnection', _testAiConnection);
-export const listAvailableModels = withLogging('configuracoes.ai.listAvailableModels', _listAvailableModels);
-export const getAiUsageSummary = withLogging('configuracoes.ai.getAiUsageSummary', _getAiUsageSummary);
-export const getTodaySpendAction = withLogging('configuracoes.ai.getTodaySpendAction', _getTodaySpendAction);
-export const getSuggestedModel = withLogging('configuracoes.ai.getSuggestedModel', _getSuggestedModel);
-export const simulateAiResponse = withLogging('configuracoes.ai.simulateAiResponse', _simulateAiResponse);
+const _wrapped_getAiConfig = withLogging('configuracoes.ai.getAiConfig', _getAiConfig);
+export async function getAiConfig(...args: Parameters<typeof _getAiConfig>) { return _wrapped_getAiConfig(...args); }
+const _wrapped_updateAiConfig = withLogging('configuracoes.ai.updateAiConfig', _updateAiConfig);
+export async function updateAiConfig(...args: Parameters<typeof _updateAiConfig>) { return _wrapped_updateAiConfig(...args); }
+const _wrapped_testAiConnection = withLogging('configuracoes.ai.testAiConnection', _testAiConnection);
+export async function testAiConnection(...args: Parameters<typeof _testAiConnection>) { return _wrapped_testAiConnection(...args); }
+const _wrapped_listAvailableModels = withLogging('configuracoes.ai.listAvailableModels', _listAvailableModels);
+export async function listAvailableModels(...args: Parameters<typeof _listAvailableModels>) { return _wrapped_listAvailableModels(...args); }
+const _wrapped_getAiUsageSummary = withLogging('configuracoes.ai.getAiUsageSummary', _getAiUsageSummary);
+export async function getAiUsageSummary(...args: Parameters<typeof _getAiUsageSummary>) { return _wrapped_getAiUsageSummary(...args); }
+const _wrapped_getTodaySpendAction = withLogging('configuracoes.ai.getTodaySpendAction', _getTodaySpendAction);
+export async function getTodaySpendAction(...args: Parameters<typeof _getTodaySpendAction>) { return _wrapped_getTodaySpendAction(...args); }
+const _wrapped_getSuggestedModel = withLogging('configuracoes.ai.getSuggestedModel', _getSuggestedModel);
+export async function getSuggestedModel(...args: Parameters<typeof _getSuggestedModel>) { return _wrapped_getSuggestedModel(...args); }
+const _wrapped_simulateAiResponse = withLogging('configuracoes.ai.simulateAiResponse', _simulateAiResponse);
+export async function simulateAiResponse(...args: Parameters<typeof _simulateAiResponse>) { return _wrapped_simulateAiResponse(...args); }

--- a/erp/src/app/(app)/configuracoes/ai/workflows/actions.ts
+++ b/erp/src/app/(app)/configuracoes/ai/workflows/actions.ts
@@ -242,8 +242,13 @@ async function _listExecutions(companyId: string, workflowId?: string, status?: 
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const listWorkflows = withLogging('workflows.listWorkflows', _listWorkflows);
-export const createWorkflow = withLogging('workflows.createWorkflow', _createWorkflow);
-export const updateWorkflow = withLogging('workflows.updateWorkflow', _updateWorkflow);
-export const getExecutionStatus = withLogging('workflows.getExecutionStatus', _getExecutionStatus);
-export const listExecutions = withLogging('workflows.listExecutions', _listExecutions);
+const _wrapped_listWorkflows = withLogging('workflows.listWorkflows', _listWorkflows);
+export async function listWorkflows(...args: Parameters<typeof _listWorkflows>) { return _wrapped_listWorkflows(...args); }
+const _wrapped_createWorkflow = withLogging('workflows.createWorkflow', _createWorkflow);
+export async function createWorkflow(...args: Parameters<typeof _createWorkflow>) { return _wrapped_createWorkflow(...args); }
+const _wrapped_updateWorkflow = withLogging('workflows.updateWorkflow', _updateWorkflow);
+export async function updateWorkflow(...args: Parameters<typeof _updateWorkflow>) { return _wrapped_updateWorkflow(...args); }
+const _wrapped_getExecutionStatus = withLogging('workflows.getExecutionStatus', _getExecutionStatus);
+export async function getExecutionStatus(...args: Parameters<typeof _getExecutionStatus>) { return _wrapped_getExecutionStatus(...args); }
+const _wrapped_listExecutions = withLogging('workflows.listExecutions', _listExecutions);
+export async function listExecutions(...args: Parameters<typeof _listExecutions>) { return _wrapped_listExecutions(...args); }

--- a/erp/src/app/(app)/configuracoes/auditoria/actions.ts
+++ b/erp/src/app/(app)/configuracoes/auditoria/actions.ts
@@ -232,8 +232,13 @@ async function _getAuditCompanies(): Promise<
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const listAuditLogs = withLogging('auditoria.listAuditLogs', _listAuditLogs);
-export const exportAuditLogsCsv = withLogging('auditoria.exportAuditLogsCsv', _exportAuditLogsCsv);
-export const getAuditEntityTypes = withLogging('auditoria.getAuditEntityTypes', _getAuditEntityTypes);
-export const getAuditUsers = withLogging('auditoria.getAuditUsers', _getAuditUsers);
-export const getAuditCompanies = withLogging('auditoria.getAuditCompanies', _getAuditCompanies);
+const _wrapped_listAuditLogs = withLogging('auditoria.listAuditLogs', _listAuditLogs);
+export async function listAuditLogs(...args: Parameters<typeof _listAuditLogs>) { return _wrapped_listAuditLogs(...args); }
+const _wrapped_exportAuditLogsCsv = withLogging('auditoria.exportAuditLogsCsv', _exportAuditLogsCsv);
+export async function exportAuditLogsCsv(...args: Parameters<typeof _exportAuditLogsCsv>) { return _wrapped_exportAuditLogsCsv(...args); }
+const _wrapped_getAuditEntityTypes = withLogging('auditoria.getAuditEntityTypes', _getAuditEntityTypes);
+export async function getAuditEntityTypes(...args: Parameters<typeof _getAuditEntityTypes>) { return _wrapped_getAuditEntityTypes(...args); }
+const _wrapped_getAuditUsers = withLogging('auditoria.getAuditUsers', _getAuditUsers);
+export async function getAuditUsers(...args: Parameters<typeof _getAuditUsers>) { return _wrapped_getAuditUsers(...args); }
+const _wrapped_getAuditCompanies = withLogging('auditoria.getAuditCompanies', _getAuditCompanies);
+export async function getAuditCompanies(...args: Parameters<typeof _getAuditCompanies>) { return _wrapped_getAuditCompanies(...args); }

--- a/erp/src/app/(app)/configuracoes/canais/actions.ts
+++ b/erp/src/app/(app)/configuracoes/canais/actions.ts
@@ -384,10 +384,17 @@ async function _testRaConnection(
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const listChannels = withLogging('canais.listChannels', _listChannels);
-export const createChannel = withLogging('canais.createChannel', _createChannel);
-export const updateChannel = withLogging('canais.updateChannel', _updateChannel);
-export const toggleChannel = withLogging('canais.toggleChannel', _toggleChannel);
-export const testChannelConnection = withLogging('canais.testChannelConnection', _testChannelConnection);
-export const getWhatsAppStatus = withLogging('canais.getWhatsAppStatus', _getWhatsAppStatus);
-export const testRaConnection = withLogging('canais.testRaConnection', _testRaConnection);
+const _wrapped_listChannels = withLogging('canais.listChannels', _listChannels);
+export async function listChannels(...args: Parameters<typeof _listChannels>) { return _wrapped_listChannels(...args); }
+const _wrapped_createChannel = withLogging('canais.createChannel', _createChannel);
+export async function createChannel(...args: Parameters<typeof _createChannel>) { return _wrapped_createChannel(...args); }
+const _wrapped_updateChannel = withLogging('canais.updateChannel', _updateChannel);
+export async function updateChannel(...args: Parameters<typeof _updateChannel>) { return _wrapped_updateChannel(...args); }
+const _wrapped_toggleChannel = withLogging('canais.toggleChannel', _toggleChannel);
+export async function toggleChannel(...args: Parameters<typeof _toggleChannel>) { return _wrapped_toggleChannel(...args); }
+const _wrapped_testChannelConnection = withLogging('canais.testChannelConnection', _testChannelConnection);
+export async function testChannelConnection(...args: Parameters<typeof _testChannelConnection>) { return _wrapped_testChannelConnection(...args); }
+const _wrapped_getWhatsAppStatus = withLogging('canais.getWhatsAppStatus', _getWhatsAppStatus);
+export async function getWhatsAppStatus(...args: Parameters<typeof _getWhatsAppStatus>) { return _wrapped_getWhatsAppStatus(...args); }
+const _wrapped_testRaConnection = withLogging('canais.testRaConnection', _testRaConnection);
+export async function testRaConnection(...args: Parameters<typeof _testRaConnection>) { return _wrapped_testRaConnection(...args); }

--- a/erp/src/app/(app)/configuracoes/compartilhamento/actions.ts
+++ b/erp/src/app/(app)/configuracoes/compartilhamento/actions.ts
@@ -226,8 +226,13 @@ async function _deleteSharingGroup(groupId: string): Promise<void> {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const listSharingGroups = withLogging('compartilhamento.listSharingGroups', _listSharingGroups);
-export const listAvailableCompanies = withLogging('compartilhamento.listAvailableCompanies', _listAvailableCompanies);
-export const createSharingGroup = withLogging('compartilhamento.createSharingGroup', _createSharingGroup);
-export const updateSharingGroup = withLogging('compartilhamento.updateSharingGroup', _updateSharingGroup);
-export const deleteSharingGroup = withLogging('compartilhamento.deleteSharingGroup', _deleteSharingGroup);
+const _wrapped_listSharingGroups = withLogging('compartilhamento.listSharingGroups', _listSharingGroups);
+export async function listSharingGroups(...args: Parameters<typeof _listSharingGroups>) { return _wrapped_listSharingGroups(...args); }
+const _wrapped_listAvailableCompanies = withLogging('compartilhamento.listAvailableCompanies', _listAvailableCompanies);
+export async function listAvailableCompanies(...args: Parameters<typeof _listAvailableCompanies>) { return _wrapped_listAvailableCompanies(...args); }
+const _wrapped_createSharingGroup = withLogging('compartilhamento.createSharingGroup', _createSharingGroup);
+export async function createSharingGroup(...args: Parameters<typeof _createSharingGroup>) { return _wrapped_createSharingGroup(...args); }
+const _wrapped_updateSharingGroup = withLogging('compartilhamento.updateSharingGroup', _updateSharingGroup);
+export async function updateSharingGroup(...args: Parameters<typeof _updateSharingGroup>) { return _wrapped_updateSharingGroup(...args); }
+const _wrapped_deleteSharingGroup = withLogging('compartilhamento.deleteSharingGroup', _deleteSharingGroup);
+export async function deleteSharingGroup(...args: Parameters<typeof _deleteSharingGroup>) { return _wrapped_deleteSharingGroup(...args); }

--- a/erp/src/app/(app)/configuracoes/empresas/actions.ts
+++ b/erp/src/app/(app)/configuracoes/empresas/actions.ts
@@ -248,8 +248,13 @@ async function _toggleCompanyStatus(id: string) {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const createCompany = withLogging('empresas.createCompany', _createCompany);
-export const updateCompany = withLogging('empresas.updateCompany', _updateCompany);
-export const listCompanies = withLogging('empresas.listCompanies', _listCompanies);
-export const getCompanyById = withLogging('empresas.getCompanyById', _getCompanyById);
-export const toggleCompanyStatus = withLogging('empresas.toggleCompanyStatus', _toggleCompanyStatus);
+const _wrapped_createCompany = withLogging('empresas.createCompany', _createCompany);
+export async function createCompany(...args: Parameters<typeof _createCompany>) { return _wrapped_createCompany(...args); }
+const _wrapped_updateCompany = withLogging('empresas.updateCompany', _updateCompany);
+export async function updateCompany(...args: Parameters<typeof _updateCompany>) { return _wrapped_updateCompany(...args); }
+const _wrapped_listCompanies = withLogging('empresas.listCompanies', _listCompanies);
+export async function listCompanies(...args: Parameters<typeof _listCompanies>) { return _wrapped_listCompanies(...args); }
+const _wrapped_getCompanyById = withLogging('empresas.getCompanyById', _getCompanyById);
+export async function getCompanyById(...args: Parameters<typeof _getCompanyById>) { return _wrapped_getCompanyById(...args); }
+const _wrapped_toggleCompanyStatus = withLogging('empresas.toggleCompanyStatus', _toggleCompanyStatus);
+export async function toggleCompanyStatus(...args: Parameters<typeof _toggleCompanyStatus>) { return _wrapped_toggleCompanyStatus(...args); }

--- a/erp/src/app/(app)/configuracoes/fiscal/actions.ts
+++ b/erp/src/app/(app)/configuracoes/fiscal/actions.ts
@@ -257,7 +257,11 @@ export { fiscalConfigCache };
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const getFiscalConfig = withLogging('fiscal.getFiscalConfig', _getFiscalConfig);
-export const saveCertificado = withLogging('fiscal.saveCertificado', _saveCertificado);
-export const saveFiscalConfig = withLogging('fiscal.saveFiscalConfig', _saveFiscalConfig);
-export const getCachedFiscalConfig = withLogging('fiscal.getCachedFiscalConfig', _getCachedFiscalConfig);
+const _wrapped_getFiscalConfig = withLogging('fiscal.getFiscalConfig', _getFiscalConfig);
+export async function getFiscalConfig(...args: Parameters<typeof _getFiscalConfig>) { return _wrapped_getFiscalConfig(...args); }
+const _wrapped_saveCertificado = withLogging('fiscal.saveCertificado', _saveCertificado);
+export async function saveCertificado(...args: Parameters<typeof _saveCertificado>) { return _wrapped_saveCertificado(...args); }
+const _wrapped_saveFiscalConfig = withLogging('fiscal.saveFiscalConfig', _saveFiscalConfig);
+export async function saveFiscalConfig(...args: Parameters<typeof _saveFiscalConfig>) { return _wrapped_saveFiscalConfig(...args); }
+const _wrapped_getCachedFiscalConfig = withLogging('fiscal.getCachedFiscalConfig', _getCachedFiscalConfig);
+export async function getCachedFiscalConfig(...args: Parameters<typeof _getCachedFiscalConfig>) { return _wrapped_getCachedFiscalConfig(...args); }

--- a/erp/src/app/(app)/configuracoes/integracoes-bancarias/actions.ts
+++ b/erp/src/app/(app)/configuracoes/integracoes-bancarias/actions.ts
@@ -621,11 +621,19 @@ async function _setDefaultProvider(
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const getPaymentProviders = withLogging('integracoes.getPaymentProviders', _getPaymentProviders);
-export const getAvailableProviders = withLogging('integracoes.getAvailableProviders', _getAvailableProviders);
-export const savePaymentProvider = withLogging('integracoes.savePaymentProvider', _savePaymentProvider);
-export const deletePaymentProvider = withLogging('integracoes.deletePaymentProvider', _deletePaymentProvider);
-export const testProviderConnection = withLogging('integracoes.testProviderConnection', _testProviderConnection);
-export const saveRoutingRules = withLogging('integracoes.saveRoutingRules', _saveRoutingRules);
-export const toggleProviderActive = withLogging('integracoes.toggleProviderActive', _toggleProviderActive);
-export const setDefaultProvider = withLogging('integracoes.setDefaultProvider', _setDefaultProvider);
+const _wrapped_getPaymentProviders = withLogging('integracoes.getPaymentProviders', _getPaymentProviders);
+export async function getPaymentProviders(...args: Parameters<typeof _getPaymentProviders>) { return _wrapped_getPaymentProviders(...args); }
+const _wrapped_getAvailableProviders = withLogging('integracoes.getAvailableProviders', _getAvailableProviders);
+export async function getAvailableProviders(...args: Parameters<typeof _getAvailableProviders>) { return _wrapped_getAvailableProviders(...args); }
+const _wrapped_savePaymentProvider = withLogging('integracoes.savePaymentProvider', _savePaymentProvider);
+export async function savePaymentProvider(...args: Parameters<typeof _savePaymentProvider>) { return _wrapped_savePaymentProvider(...args); }
+const _wrapped_deletePaymentProvider = withLogging('integracoes.deletePaymentProvider', _deletePaymentProvider);
+export async function deletePaymentProvider(...args: Parameters<typeof _deletePaymentProvider>) { return _wrapped_deletePaymentProvider(...args); }
+const _wrapped_testProviderConnection = withLogging('integracoes.testProviderConnection', _testProviderConnection);
+export async function testProviderConnection(...args: Parameters<typeof _testProviderConnection>) { return _wrapped_testProviderConnection(...args); }
+const _wrapped_saveRoutingRules = withLogging('integracoes.saveRoutingRules', _saveRoutingRules);
+export async function saveRoutingRules(...args: Parameters<typeof _saveRoutingRules>) { return _wrapped_saveRoutingRules(...args); }
+const _wrapped_toggleProviderActive = withLogging('integracoes.toggleProviderActive', _toggleProviderActive);
+export async function toggleProviderActive(...args: Parameters<typeof _toggleProviderActive>) { return _wrapped_toggleProviderActive(...args); }
+const _wrapped_setDefaultProvider = withLogging('integracoes.setDefaultProvider', _setDefaultProvider);
+export async function setDefaultProvider(...args: Parameters<typeof _setDefaultProvider>) { return _wrapped_setDefaultProvider(...args); }

--- a/erp/src/app/(app)/configuracoes/knowledge-base/actions.ts
+++ b/erp/src/app/(app)/configuracoes/knowledge-base/actions.ts
@@ -21,15 +21,27 @@ import { withLogging } from "@/lib/with-logging";
 
 // Types: import directly from "@/lib/services/kb-actions"
 
-export const listDocuments = withLogging('kb.listDocuments', _svcListDocuments);
-export const createDocument = withLogging('kb.createDocument', _svcCreateDocument);
-export const updateDocument = withLogging('kb.updateDocument', _svcUpdateDocument);
-export const deleteDocument = withLogging('kb.deleteDocument', _svcDeleteDocument);
-export const getDocumentChunks = withLogging('kb.getDocumentChunks', _svcGetDocumentChunks);
-export const searchKnowledge = withLogging('kb.searchKnowledge', _svcSearchKnowledge);
-export const getDocumentVersions = withLogging('kb.getDocumentVersions', _svcGetDocumentVersions);
-export const restoreVersion = withLogging('kb.restoreVersion', _svcRestoreVersion);
-export const getKBStats = withLogging('kb.getKBStats', _svcGetKBStats);
-export const getAllTags = withLogging('kb.getAllTags', _svcGetAllTags);
-export const uploadAndExtractText = withLogging('kb.uploadAndExtractText', _svcUploadAndExtractText);
-export const rechunkDocument = withLogging('kb.rechunkDocument', _svcRechunkDocument);
+const _wrapped_listDocuments = withLogging('kb.listDocuments', _svcListDocuments);
+export async function listDocuments(...args: Parameters<typeof _svcListDocuments>) { return _wrapped_listDocuments(...args); }
+const _wrapped_createDocument = withLogging('kb.createDocument', _svcCreateDocument);
+export async function createDocument(...args: Parameters<typeof _svcCreateDocument>) { return _wrapped_createDocument(...args); }
+const _wrapped_updateDocument = withLogging('kb.updateDocument', _svcUpdateDocument);
+export async function updateDocument(...args: Parameters<typeof _svcUpdateDocument>) { return _wrapped_updateDocument(...args); }
+const _wrapped_deleteDocument = withLogging('kb.deleteDocument', _svcDeleteDocument);
+export async function deleteDocument(...args: Parameters<typeof _svcDeleteDocument>) { return _wrapped_deleteDocument(...args); }
+const _wrapped_getDocumentChunks = withLogging('kb.getDocumentChunks', _svcGetDocumentChunks);
+export async function getDocumentChunks(...args: Parameters<typeof _svcGetDocumentChunks>) { return _wrapped_getDocumentChunks(...args); }
+const _wrapped_searchKnowledge = withLogging('kb.searchKnowledge', _svcSearchKnowledge);
+export async function searchKnowledge(...args: Parameters<typeof _svcSearchKnowledge>) { return _wrapped_searchKnowledge(...args); }
+const _wrapped_getDocumentVersions = withLogging('kb.getDocumentVersions', _svcGetDocumentVersions);
+export async function getDocumentVersions(...args: Parameters<typeof _svcGetDocumentVersions>) { return _wrapped_getDocumentVersions(...args); }
+const _wrapped_restoreVersion = withLogging('kb.restoreVersion', _svcRestoreVersion);
+export async function restoreVersion(...args: Parameters<typeof _svcRestoreVersion>) { return _wrapped_restoreVersion(...args); }
+const _wrapped_getKBStats = withLogging('kb.getKBStats', _svcGetKBStats);
+export async function getKBStats(...args: Parameters<typeof _svcGetKBStats>) { return _wrapped_getKBStats(...args); }
+const _wrapped_getAllTags = withLogging('kb.getAllTags', _svcGetAllTags);
+export async function getAllTags(...args: Parameters<typeof _svcGetAllTags>) { return _wrapped_getAllTags(...args); }
+const _wrapped_uploadAndExtractText = withLogging('kb.uploadAndExtractText', _svcUploadAndExtractText);
+export async function uploadAndExtractText(...args: Parameters<typeof _svcUploadAndExtractText>) { return _wrapped_uploadAndExtractText(...args); }
+const _wrapped_rechunkDocument = withLogging('kb.rechunkDocument', _svcRechunkDocument);
+export async function rechunkDocument(...args: Parameters<typeof _svcRechunkDocument>) { return _wrapped_rechunkDocument(...args); }

--- a/erp/src/app/(app)/configuracoes/sla/actions.ts
+++ b/erp/src/app/(app)/configuracoes/sla/actions.ts
@@ -119,7 +119,11 @@ async function _saveBusinessHours(companyId: string, data: BusinessHours): Promi
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const getSlaConfigs = withLogging('sla.config.getSlaConfigs', _getSlaConfigs);
-export const saveSlaConfigs = withLogging('sla.config.saveSlaConfigs', _saveSlaConfigs);
-export const getBusinessHours = withLogging('sla.config.getBusinessHours', _getBusinessHours);
-export const saveBusinessHours = withLogging('sla.config.saveBusinessHours', _saveBusinessHours);
+const _wrapped_getSlaConfigs = withLogging('sla.config.getSlaConfigs', _getSlaConfigs);
+export async function getSlaConfigs(...args: Parameters<typeof _getSlaConfigs>) { return _wrapped_getSlaConfigs(...args); }
+const _wrapped_saveSlaConfigs = withLogging('sla.config.saveSlaConfigs', _saveSlaConfigs);
+export async function saveSlaConfigs(...args: Parameters<typeof _saveSlaConfigs>) { return _wrapped_saveSlaConfigs(...args); }
+const _wrapped_getBusinessHours = withLogging('sla.config.getBusinessHours', _getBusinessHours);
+export async function getBusinessHours(...args: Parameters<typeof _getBusinessHours>) { return _wrapped_getBusinessHours(...args); }
+const _wrapped_saveBusinessHours = withLogging('sla.config.saveBusinessHours', _saveBusinessHours);
+export async function saveBusinessHours(...args: Parameters<typeof _saveBusinessHours>) { return _wrapped_saveBusinessHours(...args); }

--- a/erp/src/app/(app)/configuracoes/usuarios/actions.ts
+++ b/erp/src/app/(app)/configuracoes/usuarios/actions.ts
@@ -395,10 +395,17 @@ async function _getUserById(id: string) {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const createUser = withLogging('usuarios.createUser', _createUser);
-export const updateUser = withLogging('usuarios.updateUser', _updateUser);
-export const listUsers = withLogging('usuarios.listUsers', _listUsers);
-export const assignUserToCompanies = withLogging('usuarios.assignUserToCompanies', _assignUserToCompanies);
-export const toggleUserStatus = withLogging('usuarios.toggleUserStatus', _toggleUserStatus);
-export const listAllCompanies = withLogging('usuarios.listAllCompanies', _listAllCompanies);
-export const getUserById = withLogging('usuarios.getUserById', _getUserById);
+const _wrapped_createUser = withLogging('usuarios.createUser', _createUser);
+export async function createUser(...args: Parameters<typeof _createUser>) { return _wrapped_createUser(...args); }
+const _wrapped_updateUser = withLogging('usuarios.updateUser', _updateUser);
+export async function updateUser(...args: Parameters<typeof _updateUser>) { return _wrapped_updateUser(...args); }
+const _wrapped_listUsers = withLogging('usuarios.listUsers', _listUsers);
+export async function listUsers(...args: Parameters<typeof _listUsers>) { return _wrapped_listUsers(...args); }
+const _wrapped_assignUserToCompanies = withLogging('usuarios.assignUserToCompanies', _assignUserToCompanies);
+export async function assignUserToCompanies(...args: Parameters<typeof _assignUserToCompanies>) { return _wrapped_assignUserToCompanies(...args); }
+const _wrapped_toggleUserStatus = withLogging('usuarios.toggleUserStatus', _toggleUserStatus);
+export async function toggleUserStatus(...args: Parameters<typeof _toggleUserStatus>) { return _wrapped_toggleUserStatus(...args); }
+const _wrapped_listAllCompanies = withLogging('usuarios.listAllCompanies', _listAllCompanies);
+export async function listAllCompanies(...args: Parameters<typeof _listAllCompanies>) { return _wrapped_listAllCompanies(...args); }
+const _wrapped_getUserById = withLogging('usuarios.getUserById', _getUserById);
+export async function getUserById(...args: Parameters<typeof _getUserById>) { return _wrapped_getUserById(...args); }

--- a/erp/src/app/(app)/dashboard/actions.ts
+++ b/erp/src/app/(app)/dashboard/actions.ts
@@ -792,9 +792,15 @@ async function _getSlaTickets(): Promise<TicketWithSLA[]> {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const getDashboardData = withLogging('dashboard.getDashboardData', _getDashboardData);
-export const getDashboardAlerts = withLogging('dashboard.getDashboardAlerts', _getDashboardAlerts);
-export const getRevenueExpenseChart = withLogging('dashboard.getRevenueExpenseChart', _getRevenueExpenseChart);
-export const getUpcomingPayables = withLogging('dashboard.getUpcomingPayables', _getUpcomingPayables);
-export const getRecentProposals = withLogging('dashboard.getRecentProposals', _getRecentProposals);
-export const getSlaTickets = withLogging('dashboard.getSlaTickets', _getSlaTickets);
+const _wrapped_getDashboardData = withLogging('dashboard.getDashboardData', _getDashboardData);
+export async function getDashboardData(...args: Parameters<typeof _getDashboardData>) { return _wrapped_getDashboardData(...args); }
+const _wrapped_getDashboardAlerts = withLogging('dashboard.getDashboardAlerts', _getDashboardAlerts);
+export async function getDashboardAlerts(...args: Parameters<typeof _getDashboardAlerts>) { return _wrapped_getDashboardAlerts(...args); }
+const _wrapped_getRevenueExpenseChart = withLogging('dashboard.getRevenueExpenseChart', _getRevenueExpenseChart);
+export async function getRevenueExpenseChart(...args: Parameters<typeof _getRevenueExpenseChart>) { return _wrapped_getRevenueExpenseChart(...args); }
+const _wrapped_getUpcomingPayables = withLogging('dashboard.getUpcomingPayables', _getUpcomingPayables);
+export async function getUpcomingPayables(...args: Parameters<typeof _getUpcomingPayables>) { return _wrapped_getUpcomingPayables(...args); }
+const _wrapped_getRecentProposals = withLogging('dashboard.getRecentProposals', _getRecentProposals);
+export async function getRecentProposals(...args: Parameters<typeof _getRecentProposals>) { return _wrapped_getRecentProposals(...args); }
+const _wrapped_getSlaTickets = withLogging('dashboard.getSlaTickets', _getSlaTickets);
+export async function getSlaTickets(...args: Parameters<typeof _getSlaTickets>) { return _wrapped_getSlaTickets(...args); }

--- a/erp/src/app/(app)/financeiro/conciliacao/actions.ts
+++ b/erp/src/app/(app)/financeiro/conciliacao/actions.ts
@@ -699,11 +699,19 @@ async function _unmatchTransaction(
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const importBankTransactions = withLogging('conciliacao.importBankTransactions', _importBankTransactions);
-export const listBankTransactions = withLogging('conciliacao.listBankTransactions', _listBankTransactions);
-export const deleteBankTransaction = withLogging('conciliacao.deleteBankTransaction', _deleteBankTransaction);
-export const getReconciliationSummary = withLogging('conciliacao.getReconciliationSummary', _getReconciliationSummary);
-export const listUnmatchedSystemRecords = withLogging('conciliacao.listUnmatchedSystemRecords', _listUnmatchedSystemRecords);
-export const autoMatchTransactions = withLogging('conciliacao.autoMatchTransactions', _autoMatchTransactions);
-export const manualMatchTransaction = withLogging('conciliacao.manualMatchTransaction', _manualMatchTransaction);
-export const unmatchTransaction = withLogging('conciliacao.unmatchTransaction', _unmatchTransaction);
+const _wrapped_importBankTransactions = withLogging('conciliacao.importBankTransactions', _importBankTransactions);
+export async function importBankTransactions(...args: Parameters<typeof _importBankTransactions>) { return _wrapped_importBankTransactions(...args); }
+const _wrapped_listBankTransactions = withLogging('conciliacao.listBankTransactions', _listBankTransactions);
+export async function listBankTransactions(...args: Parameters<typeof _listBankTransactions>) { return _wrapped_listBankTransactions(...args); }
+const _wrapped_deleteBankTransaction = withLogging('conciliacao.deleteBankTransaction', _deleteBankTransaction);
+export async function deleteBankTransaction(...args: Parameters<typeof _deleteBankTransaction>) { return _wrapped_deleteBankTransaction(...args); }
+const _wrapped_getReconciliationSummary = withLogging('conciliacao.getReconciliationSummary', _getReconciliationSummary);
+export async function getReconciliationSummary(...args: Parameters<typeof _getReconciliationSummary>) { return _wrapped_getReconciliationSummary(...args); }
+const _wrapped_listUnmatchedSystemRecords = withLogging('conciliacao.listUnmatchedSystemRecords', _listUnmatchedSystemRecords);
+export async function listUnmatchedSystemRecords(...args: Parameters<typeof _listUnmatchedSystemRecords>) { return _wrapped_listUnmatchedSystemRecords(...args); }
+const _wrapped_autoMatchTransactions = withLogging('conciliacao.autoMatchTransactions', _autoMatchTransactions);
+export async function autoMatchTransactions(...args: Parameters<typeof _autoMatchTransactions>) { return _wrapped_autoMatchTransactions(...args); }
+const _wrapped_manualMatchTransaction = withLogging('conciliacao.manualMatchTransaction', _manualMatchTransaction);
+export async function manualMatchTransaction(...args: Parameters<typeof _manualMatchTransaction>) { return _wrapped_manualMatchTransaction(...args); }
+const _wrapped_unmatchTransaction = withLogging('conciliacao.unmatchTransaction', _unmatchTransaction);
+export async function unmatchTransaction(...args: Parameters<typeof _unmatchTransaction>) { return _wrapped_unmatchTransaction(...args); }

--- a/erp/src/app/(app)/financeiro/dre/actions.ts
+++ b/erp/src/app/(app)/financeiro/dre/actions.ts
@@ -426,6 +426,9 @@ async function _getCompaniesForDRE() {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const getDREData = withLogging('dre.getDREData', _getDREData);
-export const getDREConsolidated = withLogging('dre.getDREConsolidated', _getDREConsolidated);
-export const getCompaniesForDRE = withLogging('dre.getCompaniesForDRE', _getCompaniesForDRE);
+const _wrapped_getDREData = withLogging('dre.getDREData', _getDREData);
+export async function getDREData(...args: Parameters<typeof _getDREData>) { return _wrapped_getDREData(...args); }
+const _wrapped_getDREConsolidated = withLogging('dre.getDREConsolidated', _getDREConsolidated);
+export async function getDREConsolidated(...args: Parameters<typeof _getDREConsolidated>) { return _wrapped_getDREConsolidated(...args); }
+const _wrapped_getCompaniesForDRE = withLogging('dre.getCompaniesForDRE', _getCompaniesForDRE);
+export async function getCompaniesForDRE(...args: Parameters<typeof _getCompaniesForDRE>) { return _wrapped_getCompaniesForDRE(...args); }

--- a/erp/src/app/(app)/financeiro/fluxo-de-caixa/actions.ts
+++ b/erp/src/app/(app)/financeiro/fluxo-de-caixa/actions.ts
@@ -304,5 +304,7 @@ async function _getCompaniesForCashFlow() {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const getCashFlowData = withLogging('fluxoCaixa.getCashFlowData', _getCashFlowData);
-export const getCompaniesForCashFlow = withLogging('fluxoCaixa.getCompaniesForCashFlow', _getCompaniesForCashFlow);
+const _wrapped_getCashFlowData = withLogging('fluxoCaixa.getCashFlowData', _getCashFlowData);
+export async function getCashFlowData(...args: Parameters<typeof _getCashFlowData>) { return _wrapped_getCashFlowData(...args); }
+const _wrapped_getCompaniesForCashFlow = withLogging('fluxoCaixa.getCompaniesForCashFlow', _getCompaniesForCashFlow);
+export async function getCompaniesForCashFlow(...args: Parameters<typeof _getCompaniesForCashFlow>) { return _wrapped_getCompaniesForCashFlow(...args); }

--- a/erp/src/app/(app)/financeiro/pagar/actions.ts
+++ b/erp/src/app/(app)/financeiro/pagar/actions.ts
@@ -399,9 +399,15 @@ async function _listCategoriesForSelect(companyId: string): Promise<CategoryOpti
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const getPayableAlerts = withLogging('pagar.getPayableAlerts', _getPayableAlerts);
-export const listPayables = withLogging('pagar.listPayables', _listPayables);
-export const createPayable = withLogging('pagar.createPayable', _createPayable);
-export const updatePayable = withLogging('pagar.updatePayable', _updatePayable);
-export const markPayableAsPaid = withLogging('pagar.markPayableAsPaid', _markPayableAsPaid);
-export const listCategoriesForSelect = withLogging('pagar.listCategoriesForSelect', _listCategoriesForSelect);
+const _wrapped_getPayableAlerts = withLogging('pagar.getPayableAlerts', _getPayableAlerts);
+export async function getPayableAlerts(...args: Parameters<typeof _getPayableAlerts>) { return _wrapped_getPayableAlerts(...args); }
+const _wrapped_listPayables = withLogging('pagar.listPayables', _listPayables);
+export async function listPayables(...args: Parameters<typeof _listPayables>) { return _wrapped_listPayables(...args); }
+const _wrapped_createPayable = withLogging('pagar.createPayable', _createPayable);
+export async function createPayable(...args: Parameters<typeof _createPayable>) { return _wrapped_createPayable(...args); }
+const _wrapped_updatePayable = withLogging('pagar.updatePayable', _updatePayable);
+export async function updatePayable(...args: Parameters<typeof _updatePayable>) { return _wrapped_updatePayable(...args); }
+const _wrapped_markPayableAsPaid = withLogging('pagar.markPayableAsPaid', _markPayableAsPaid);
+export async function markPayableAsPaid(...args: Parameters<typeof _markPayableAsPaid>) { return _wrapped_markPayableAsPaid(...args); }
+const _wrapped_listCategoriesForSelect = withLogging('pagar.listCategoriesForSelect', _listCategoriesForSelect);
+export async function listCategoriesForSelect(...args: Parameters<typeof _listCategoriesForSelect>) { return _wrapped_listCategoriesForSelect(...args); }

--- a/erp/src/app/(app)/financeiro/receber/actions.ts
+++ b/erp/src/app/(app)/financeiro/receber/actions.ts
@@ -247,7 +247,11 @@ async function _listClientsForSelect(companyId: string) {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const listReceivables = withLogging('receber.listReceivables', _listReceivables);
-export const createReceivable = withLogging('receber.createReceivable', _createReceivable);
-export const markReceivableAsPaid = withLogging('receber.markReceivableAsPaid', _markReceivableAsPaid);
-export const listClientsForSelect = withLogging('receber.listClientsForSelect', _listClientsForSelect);
+const _wrapped_listReceivables = withLogging('receber.listReceivables', _listReceivables);
+export async function listReceivables(...args: Parameters<typeof _listReceivables>) { return _wrapped_listReceivables(...args); }
+const _wrapped_createReceivable = withLogging('receber.createReceivable', _createReceivable);
+export async function createReceivable(...args: Parameters<typeof _createReceivable>) { return _wrapped_createReceivable(...args); }
+const _wrapped_markReceivableAsPaid = withLogging('receber.markReceivableAsPaid', _markReceivableAsPaid);
+export async function markReceivableAsPaid(...args: Parameters<typeof _markReceivableAsPaid>) { return _wrapped_markReceivableAsPaid(...args); }
+const _wrapped_listClientsForSelect = withLogging('receber.listClientsForSelect', _listClientsForSelect);
+export async function listClientsForSelect(...args: Parameters<typeof _listClientsForSelect>) { return _wrapped_listClientsForSelect(...args); }

--- a/erp/src/app/(app)/fiscal/impostos/actions.ts
+++ b/erp/src/app/(app)/fiscal/impostos/actions.ts
@@ -323,6 +323,9 @@ async function _markTaxEntryAsPaid(entryId: string, companyId: string) {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const getTaxDashboardData = withLogging('impostos.getTaxDashboardData', _getTaxDashboardData);
-export const createTaxEntry = withLogging('impostos.createTaxEntry', _createTaxEntry);
-export const markTaxEntryAsPaid = withLogging('impostos.markTaxEntryAsPaid', _markTaxEntryAsPaid);
+const _wrapped_getTaxDashboardData = withLogging('impostos.getTaxDashboardData', _getTaxDashboardData);
+export async function getTaxDashboardData(...args: Parameters<typeof _getTaxDashboardData>) { return _wrapped_getTaxDashboardData(...args); }
+const _wrapped_createTaxEntry = withLogging('impostos.createTaxEntry', _createTaxEntry);
+export async function createTaxEntry(...args: Parameters<typeof _createTaxEntry>) { return _wrapped_createTaxEntry(...args); }
+const _wrapped_markTaxEntryAsPaid = withLogging('impostos.markTaxEntryAsPaid', _markTaxEntryAsPaid);
+export async function markTaxEntryAsPaid(...args: Parameters<typeof _markTaxEntryAsPaid>) { return _wrapped_markTaxEntryAsPaid(...args); }

--- a/erp/src/app/(app)/fiscal/notas-fiscais/actions.ts
+++ b/erp/src/app/(app)/fiscal/notas-fiscais/actions.ts
@@ -272,7 +272,11 @@ async function _emitPendingInvoice(invoiceId: string, companyId: string) {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const listInvoices = withLogging('notasFiscais.listInvoices', _listInvoices);
-export const listClientsForSelect = withLogging('notasFiscais.listClientsForSelect', _listClientsForSelect);
-export const cancelInvoice = withLogging('notasFiscais.cancelInvoice', _cancelInvoice);
-export const emitPendingInvoice = withLogging('notasFiscais.emitPendingInvoice', _emitPendingInvoice);
+const _wrapped_listInvoices = withLogging('notasFiscais.listInvoices', _listInvoices);
+export async function listInvoices(...args: Parameters<typeof _listInvoices>) { return _wrapped_listInvoices(...args); }
+const _wrapped_listClientsForSelect = withLogging('notasFiscais.listClientsForSelect', _listClientsForSelect);
+export async function listClientsForSelect(...args: Parameters<typeof _listClientsForSelect>) { return _wrapped_listClientsForSelect(...args); }
+const _wrapped_cancelInvoice = withLogging('notasFiscais.cancelInvoice', _cancelInvoice);
+export async function cancelInvoice(...args: Parameters<typeof _cancelInvoice>) { return _wrapped_cancelInvoice(...args); }
+const _wrapped_emitPendingInvoice = withLogging('notasFiscais.emitPendingInvoice', _emitPendingInvoice);
+export async function emitPendingInvoice(...args: Parameters<typeof _emitPendingInvoice>) { return _wrapped_emitPendingInvoice(...args); }

--- a/erp/src/app/(app)/fiscal/plano-de-contas/actions.ts
+++ b/erp/src/app/(app)/fiscal/plano-de-contas/actions.ts
@@ -488,9 +488,15 @@ async function _deleteAccount(id: string, companyId: string) {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const seedDefaultChartOfAccounts = withLogging('planoContas.seedDefaultChartOfAccounts', _seedDefaultChartOfAccounts);
-export const listChartOfAccounts = withLogging('planoContas.listChartOfAccounts', _listChartOfAccounts);
-export const listParentOptions = withLogging('planoContas.listParentOptions', _listParentOptions);
-export const createAccount = withLogging('planoContas.createAccount', _createAccount);
-export const updateAccount = withLogging('planoContas.updateAccount', _updateAccount);
-export const deleteAccount = withLogging('planoContas.deleteAccount', _deleteAccount);
+const _wrapped_seedDefaultChartOfAccounts = withLogging('planoContas.seedDefaultChartOfAccounts', _seedDefaultChartOfAccounts);
+export async function seedDefaultChartOfAccounts(...args: Parameters<typeof _seedDefaultChartOfAccounts>) { return _wrapped_seedDefaultChartOfAccounts(...args); }
+const _wrapped_listChartOfAccounts = withLogging('planoContas.listChartOfAccounts', _listChartOfAccounts);
+export async function listChartOfAccounts(...args: Parameters<typeof _listChartOfAccounts>) { return _wrapped_listChartOfAccounts(...args); }
+const _wrapped_listParentOptions = withLogging('planoContas.listParentOptions', _listParentOptions);
+export async function listParentOptions(...args: Parameters<typeof _listParentOptions>) { return _wrapped_listParentOptions(...args); }
+const _wrapped_createAccount = withLogging('planoContas.createAccount', _createAccount);
+export async function createAccount(...args: Parameters<typeof _createAccount>) { return _wrapped_createAccount(...args); }
+const _wrapped_updateAccount = withLogging('planoContas.updateAccount', _updateAccount);
+export async function updateAccount(...args: Parameters<typeof _updateAccount>) { return _wrapped_updateAccount(...args); }
+const _wrapped_deleteAccount = withLogging('planoContas.deleteAccount', _deleteAccount);
+export async function deleteAccount(...args: Parameters<typeof _deleteAccount>) { return _wrapped_deleteAccount(...args); }

--- a/erp/src/app/(app)/sac/analytics/actions.ts
+++ b/erp/src/app/(app)/sac/analytics/actions.ts
@@ -471,13 +471,23 @@ async function _getTopTools(
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const getAiKpis = withLogging('sac.analytics.getAiKpis', _getAiKpis);
-export const getCostByDay = withLogging('sac.analytics.getCostByDay', _getCostByDay);
-export const getCostByChannel = withLogging('sac.analytics.getCostByChannel', _getCostByChannel);
-export const getTopTicketsByCost = withLogging('sac.analytics.getTopTicketsByCost', _getTopTicketsByCost);
-export const getConfidenceByChannel = withLogging('sac.analytics.getConfidenceByChannel', _getConfidenceByChannel);
-export const getSuggestionBreakdown = withLogging('sac.analytics.getSuggestionBreakdown', _getSuggestionBreakdown);
-export const getConfidenceCalibration = withLogging('sac.analytics.getConfidenceCalibration', _getConfidenceCalibration);
-export const getEscalationRate = withLogging('sac.analytics.getEscalationRate', _getEscalationRate);
-export const getRecentEscalations = withLogging('sac.analytics.getRecentEscalations', _getRecentEscalations);
-export const getTopTools = withLogging('sac.analytics.getTopTools', _getTopTools);
+const _wrapped_getAiKpis = withLogging('sac.analytics.getAiKpis', _getAiKpis);
+export async function getAiKpis(...args: Parameters<typeof _getAiKpis>) { return _wrapped_getAiKpis(...args); }
+const _wrapped_getCostByDay = withLogging('sac.analytics.getCostByDay', _getCostByDay);
+export async function getCostByDay(...args: Parameters<typeof _getCostByDay>) { return _wrapped_getCostByDay(...args); }
+const _wrapped_getCostByChannel = withLogging('sac.analytics.getCostByChannel', _getCostByChannel);
+export async function getCostByChannel(...args: Parameters<typeof _getCostByChannel>) { return _wrapped_getCostByChannel(...args); }
+const _wrapped_getTopTicketsByCost = withLogging('sac.analytics.getTopTicketsByCost', _getTopTicketsByCost);
+export async function getTopTicketsByCost(...args: Parameters<typeof _getTopTicketsByCost>) { return _wrapped_getTopTicketsByCost(...args); }
+const _wrapped_getConfidenceByChannel = withLogging('sac.analytics.getConfidenceByChannel', _getConfidenceByChannel);
+export async function getConfidenceByChannel(...args: Parameters<typeof _getConfidenceByChannel>) { return _wrapped_getConfidenceByChannel(...args); }
+const _wrapped_getSuggestionBreakdown = withLogging('sac.analytics.getSuggestionBreakdown', _getSuggestionBreakdown);
+export async function getSuggestionBreakdown(...args: Parameters<typeof _getSuggestionBreakdown>) { return _wrapped_getSuggestionBreakdown(...args); }
+const _wrapped_getConfidenceCalibration = withLogging('sac.analytics.getConfidenceCalibration', _getConfidenceCalibration);
+export async function getConfidenceCalibration(...args: Parameters<typeof _getConfidenceCalibration>) { return _wrapped_getConfidenceCalibration(...args); }
+const _wrapped_getEscalationRate = withLogging('sac.analytics.getEscalationRate', _getEscalationRate);
+export async function getEscalationRate(...args: Parameters<typeof _getEscalationRate>) { return _wrapped_getEscalationRate(...args); }
+const _wrapped_getRecentEscalations = withLogging('sac.analytics.getRecentEscalations', _getRecentEscalations);
+export async function getRecentEscalations(...args: Parameters<typeof _getRecentEscalations>) { return _wrapped_getRecentEscalations(...args); }
+const _wrapped_getTopTools = withLogging('sac.analytics.getTopTools', _getTopTools);
+export async function getTopTools(...args: Parameters<typeof _getTopTools>) { return _wrapped_getTopTools(...args); }

--- a/erp/src/app/(app)/sac/analytics/alert-actions.ts
+++ b/erp/src/app/(app)/sac/analytics/alert-actions.ts
@@ -103,7 +103,11 @@ async function _deleteAlert(id: string): Promise<void> {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const listAlerts = withLogging('sac.alerts.listAlerts', _listAlerts);
-export const upsertAlert = withLogging('sac.alerts.upsertAlert', _upsertAlert);
-export const toggleAlert = withLogging('sac.alerts.toggleAlert', _toggleAlert);
-export const deleteAlert = withLogging('sac.alerts.deleteAlert', _deleteAlert);
+const _wrapped_listAlerts = withLogging('sac.alerts.listAlerts', _listAlerts);
+export async function listAlerts(...args: Parameters<typeof _listAlerts>) { return _wrapped_listAlerts(...args); }
+const _wrapped_upsertAlert = withLogging('sac.alerts.upsertAlert', _upsertAlert);
+export async function upsertAlert(...args: Parameters<typeof _upsertAlert>) { return _wrapped_upsertAlert(...args); }
+const _wrapped_toggleAlert = withLogging('sac.alerts.toggleAlert', _toggleAlert);
+export async function toggleAlert(...args: Parameters<typeof _toggleAlert>) { return _wrapped_toggleAlert(...args); }
+const _wrapped_deleteAlert = withLogging('sac.alerts.deleteAlert', _deleteAlert);
+export async function deleteAlert(...args: Parameters<typeof _deleteAlert>) { return _wrapped_deleteAlert(...args); }

--- a/erp/src/app/(app)/sac/feedback/actions.ts
+++ b/erp/src/app/(app)/sac/feedback/actions.ts
@@ -66,7 +66,11 @@ async function _getConfidenceCalibration(companyId: string, from?: string, to?: 
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const getFeedbackSummary = withLogging('sac.feedback.getFeedbackSummary', _getFeedbackSummary);
-export const getRejectReasons = withLogging('sac.feedback.getRejectReasons', _getRejectReasons);
-export const getEditPatterns = withLogging('sac.feedback.getEditPatterns', _getEditPatterns);
-export const getConfidenceCalibration = withLogging('sac.feedback.getConfidenceCalibration', _getConfidenceCalibration);
+const _wrapped_getFeedbackSummary = withLogging('sac.feedback.getFeedbackSummary', _getFeedbackSummary);
+export async function getFeedbackSummary(...args: Parameters<typeof _getFeedbackSummary>) { return _wrapped_getFeedbackSummary(...args); }
+const _wrapped_getRejectReasons = withLogging('sac.feedback.getRejectReasons', _getRejectReasons);
+export async function getRejectReasons(...args: Parameters<typeof _getRejectReasons>) { return _wrapped_getRejectReasons(...args); }
+const _wrapped_getEditPatterns = withLogging('sac.feedback.getEditPatterns', _getEditPatterns);
+export async function getEditPatterns(...args: Parameters<typeof _getEditPatterns>) { return _wrapped_getEditPatterns(...args); }
+const _wrapped_getConfidenceCalibration = withLogging('sac.feedback.getConfidenceCalibration', _getConfidenceCalibration);
+export async function getConfidenceCalibration(...args: Parameters<typeof _getConfidenceCalibration>) { return _wrapped_getConfidenceCalibration(...args); }

--- a/erp/src/app/(app)/sac/sla/actions.ts
+++ b/erp/src/app/(app)/sac/sla/actions.ts
@@ -180,8 +180,13 @@ async function _getSlaDashboard(companyId: string): Promise<SlaDashboardResult> 
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const listSlaPolicies = withLogging('sac.sla.listSlaPolicies', _listSlaPolicies);
-export const createSlaPolicy = withLogging('sac.sla.createSlaPolicy', _createSlaPolicy);
-export const updateSlaPolicy = withLogging('sac.sla.updateSlaPolicy', _updateSlaPolicy);
-export const deleteSlaPolicy = withLogging('sac.sla.deleteSlaPolicy', _deleteSlaPolicy);
-export const getSlaDashboard = withLogging('sac.sla.getSlaDashboard', _getSlaDashboard);
+const _wrapped_listSlaPolicies = withLogging('sac.sla.listSlaPolicies', _listSlaPolicies);
+export async function listSlaPolicies(...args: Parameters<typeof _listSlaPolicies>) { return _wrapped_listSlaPolicies(...args); }
+const _wrapped_createSlaPolicy = withLogging('sac.sla.createSlaPolicy', _createSlaPolicy);
+export async function createSlaPolicy(...args: Parameters<typeof _createSlaPolicy>) { return _wrapped_createSlaPolicy(...args); }
+const _wrapped_updateSlaPolicy = withLogging('sac.sla.updateSlaPolicy', _updateSlaPolicy);
+export async function updateSlaPolicy(...args: Parameters<typeof _updateSlaPolicy>) { return _wrapped_updateSlaPolicy(...args); }
+const _wrapped_deleteSlaPolicy = withLogging('sac.sla.deleteSlaPolicy', _deleteSlaPolicy);
+export async function deleteSlaPolicy(...args: Parameters<typeof _deleteSlaPolicy>) { return _wrapped_deleteSlaPolicy(...args); }
+const _wrapped_getSlaDashboard = withLogging('sac.sla.getSlaDashboard', _getSlaDashboard);
+export async function getSlaDashboard(...args: Parameters<typeof _getSlaDashboard>) { return _wrapped_getSlaDashboard(...args); }

--- a/erp/src/app/(app)/sac/suggestions/actions.ts
+++ b/erp/src/app/(app)/sac/suggestions/actions.ts
@@ -116,5 +116,7 @@ async function _getSuggestionStats(companyId: string) {
 // ---------------------------------------------------------------------------
 // Wrapped exports with logging
 // ---------------------------------------------------------------------------
-export const listSuggestions = withLogging('sac.suggestions.listSuggestions', _listSuggestions);
-export const getSuggestionStats = withLogging('sac.suggestions.getSuggestionStats', _getSuggestionStats);
+const _wrapped_listSuggestions = withLogging('sac.suggestions.listSuggestions', _listSuggestions);
+export async function listSuggestions(...args: Parameters<typeof _listSuggestions>) { return _wrapped_listSuggestions(...args); }
+const _wrapped_getSuggestionStats = withLogging('sac.suggestions.getSuggestionStats', _getSuggestionStats);
+export async function getSuggestionStats(...args: Parameters<typeof _getSuggestionStats>) { return _wrapped_getSuggestionStats(...args); }

--- a/erp/src/app/(app)/sac/tickets/actions.ts
+++ b/erp/src/app/(app)/sac/tickets/actions.ts
@@ -2937,41 +2937,79 @@ async function _getKanbanBootstrap(
 // ---------------------------------------------------------------------------
 // Wrapped exports with structured logging
 // ---------------------------------------------------------------------------
-export const listTickets = withLogging('sac.tickets.listTickets', _listTickets);
-export const getTicketTabCounts = withLogging('sac.tickets.getTicketTabCounts', _getTicketTabCounts);
-export const getSlaAlertCounts = withLogging('sac.tickets.getSlaAlertCounts', _getSlaAlertCounts);
-export const createTicket = withLogging('sac.tickets.createTicket', _createTicket);
-export const listClientsForSelect = withLogging('sac.tickets.listClientsForSelect', _listClientsForSelect);
-export const listUsersForAssign = withLogging('sac.tickets.listUsersForAssign', _listUsersForAssign);
-export const getTicketById = withLogging('sac.tickets.getTicketById', _getTicketById);
-export const updateTicketStatus = withLogging('sac.tickets.updateTicketStatus', _updateTicketStatus);
-export const toggleTicketAi = withLogging('sac.tickets.toggleTicketAi', _toggleTicketAi);
-export const getAiConfigEnabled = withLogging('sac.tickets.getAiConfigEnabled', _getAiConfigEnabled);
-export const reassignTicket = withLogging('sac.tickets.reassignTicket', _reassignTicket);
-export const listTicketMessages = withLogging('sac.tickets.listTicketMessages', _listTicketMessages);
-export const createTicketReply = withLogging('sac.tickets.createTicketReply', _createTicketReply);
-export const listTimelineEvents = withLogging('sac.tickets.listTimelineEvents', _listTimelineEvents);
-export const createInternalNote = withLogging('sac.tickets.createInternalNote', _createInternalNote);
-export const getEmailRecipients = withLogging('sac.tickets.getEmailRecipients', _getEmailRecipients);
-export const sendEmailReply = withLogging('sac.tickets.sendEmailReply', _sendEmailReply);
-export const attachFileToTicket = withLogging('sac.tickets.attachFileToTicket', _attachFileToTicket);
-export const getWhatsAppRecipients = withLogging('sac.tickets.getWhatsAppRecipients', _getWhatsAppRecipients);
-export const sendWhatsAppMessage = withLogging('sac.tickets.sendWhatsAppMessage', _sendWhatsAppMessage);
-export const getClientFinancialSummary = withLogging('sac.tickets.getClientFinancialSummary', _getClientFinancialSummary);
-export const searchClientsForLink = withLogging('sac.tickets.searchClientsForLink', _searchClientsForLink);
-export const linkContactToClient = withLogging('sac.tickets.linkContactToClient', _linkContactToClient);
-export const createClientAndLink = withLogging('sac.tickets.createClientAndLink', _createClientAndLink);
-export const getTicketRefunds = withLogging('sac.tickets.getTicketRefunds', _getTicketRefunds);
-export const getUserRole = withLogging('sac.tickets.getUserRole', _getUserRole);
-export const requestRefund = withLogging('sac.tickets.requestRefund', _requestRefund);
-export const approveRefund = withLogging('sac.tickets.approveRefund', _approveRefund);
-export const rejectRefund = withLogging('sac.tickets.rejectRefund', _rejectRefund);
-export const executeRefund = withLogging('sac.tickets.executeRefund', _executeRefund);
-export const getTicketListBootstrap = withLogging('sac.tickets.getTicketListBootstrap', _getTicketListBootstrap);
-export const addTag = withLogging('sac.tickets.addTag', _addTag);
-export const removeTag = withLogging('sac.tickets.removeTag', _removeTag);
-export const getCancellationInfo = withLogging('sac.tickets.getCancellationInfo', _getCancellationInfo);
-export const requestCancellation = withLogging('sac.tickets.requestCancellation', _requestCancellation);
-export const approveCancellation = withLogging('sac.tickets.approveCancellation', _approveCancellation);
-export const getTicketDetailBootstrap = withLogging('sac.tickets.getTicketDetailBootstrap', _getTicketDetailBootstrap);
-export const getKanbanBootstrap = withLogging('sac.tickets.getKanbanBootstrap', _getKanbanBootstrap);
+const _wrapped_listTickets = withLogging('sac.tickets.listTickets', _listTickets);
+export async function listTickets(...args: Parameters<typeof _listTickets>) { return _wrapped_listTickets(...args); }
+const _wrapped_getTicketTabCounts = withLogging('sac.tickets.getTicketTabCounts', _getTicketTabCounts);
+export async function getTicketTabCounts(...args: Parameters<typeof _getTicketTabCounts>) { return _wrapped_getTicketTabCounts(...args); }
+const _wrapped_getSlaAlertCounts = withLogging('sac.tickets.getSlaAlertCounts', _getSlaAlertCounts);
+export async function getSlaAlertCounts(...args: Parameters<typeof _getSlaAlertCounts>) { return _wrapped_getSlaAlertCounts(...args); }
+const _wrapped_createTicket = withLogging('sac.tickets.createTicket', _createTicket);
+export async function createTicket(...args: Parameters<typeof _createTicket>) { return _wrapped_createTicket(...args); }
+const _wrapped_listClientsForSelect = withLogging('sac.tickets.listClientsForSelect', _listClientsForSelect);
+export async function listClientsForSelect(...args: Parameters<typeof _listClientsForSelect>) { return _wrapped_listClientsForSelect(...args); }
+const _wrapped_listUsersForAssign = withLogging('sac.tickets.listUsersForAssign', _listUsersForAssign);
+export async function listUsersForAssign(...args: Parameters<typeof _listUsersForAssign>) { return _wrapped_listUsersForAssign(...args); }
+const _wrapped_getTicketById = withLogging('sac.tickets.getTicketById', _getTicketById);
+export async function getTicketById(...args: Parameters<typeof _getTicketById>) { return _wrapped_getTicketById(...args); }
+const _wrapped_updateTicketStatus = withLogging('sac.tickets.updateTicketStatus', _updateTicketStatus);
+export async function updateTicketStatus(...args: Parameters<typeof _updateTicketStatus>) { return _wrapped_updateTicketStatus(...args); }
+const _wrapped_toggleTicketAi = withLogging('sac.tickets.toggleTicketAi', _toggleTicketAi);
+export async function toggleTicketAi(...args: Parameters<typeof _toggleTicketAi>) { return _wrapped_toggleTicketAi(...args); }
+const _wrapped_getAiConfigEnabled = withLogging('sac.tickets.getAiConfigEnabled', _getAiConfigEnabled);
+export async function getAiConfigEnabled(...args: Parameters<typeof _getAiConfigEnabled>) { return _wrapped_getAiConfigEnabled(...args); }
+const _wrapped_reassignTicket = withLogging('sac.tickets.reassignTicket', _reassignTicket);
+export async function reassignTicket(...args: Parameters<typeof _reassignTicket>) { return _wrapped_reassignTicket(...args); }
+const _wrapped_listTicketMessages = withLogging('sac.tickets.listTicketMessages', _listTicketMessages);
+export async function listTicketMessages(...args: Parameters<typeof _listTicketMessages>) { return _wrapped_listTicketMessages(...args); }
+const _wrapped_createTicketReply = withLogging('sac.tickets.createTicketReply', _createTicketReply);
+export async function createTicketReply(...args: Parameters<typeof _createTicketReply>) { return _wrapped_createTicketReply(...args); }
+const _wrapped_listTimelineEvents = withLogging('sac.tickets.listTimelineEvents', _listTimelineEvents);
+export async function listTimelineEvents(...args: Parameters<typeof _listTimelineEvents>) { return _wrapped_listTimelineEvents(...args); }
+const _wrapped_createInternalNote = withLogging('sac.tickets.createInternalNote', _createInternalNote);
+export async function createInternalNote(...args: Parameters<typeof _createInternalNote>) { return _wrapped_createInternalNote(...args); }
+const _wrapped_getEmailRecipients = withLogging('sac.tickets.getEmailRecipients', _getEmailRecipients);
+export async function getEmailRecipients(...args: Parameters<typeof _getEmailRecipients>) { return _wrapped_getEmailRecipients(...args); }
+const _wrapped_sendEmailReply = withLogging('sac.tickets.sendEmailReply', _sendEmailReply);
+export async function sendEmailReply(...args: Parameters<typeof _sendEmailReply>) { return _wrapped_sendEmailReply(...args); }
+const _wrapped_attachFileToTicket = withLogging('sac.tickets.attachFileToTicket', _attachFileToTicket);
+export async function attachFileToTicket(...args: Parameters<typeof _attachFileToTicket>) { return _wrapped_attachFileToTicket(...args); }
+const _wrapped_getWhatsAppRecipients = withLogging('sac.tickets.getWhatsAppRecipients', _getWhatsAppRecipients);
+export async function getWhatsAppRecipients(...args: Parameters<typeof _getWhatsAppRecipients>) { return _wrapped_getWhatsAppRecipients(...args); }
+const _wrapped_sendWhatsAppMessage = withLogging('sac.tickets.sendWhatsAppMessage', _sendWhatsAppMessage);
+export async function sendWhatsAppMessage(...args: Parameters<typeof _sendWhatsAppMessage>) { return _wrapped_sendWhatsAppMessage(...args); }
+const _wrapped_getClientFinancialSummary = withLogging('sac.tickets.getClientFinancialSummary', _getClientFinancialSummary);
+export async function getClientFinancialSummary(...args: Parameters<typeof _getClientFinancialSummary>) { return _wrapped_getClientFinancialSummary(...args); }
+const _wrapped_searchClientsForLink = withLogging('sac.tickets.searchClientsForLink', _searchClientsForLink);
+export async function searchClientsForLink(...args: Parameters<typeof _searchClientsForLink>) { return _wrapped_searchClientsForLink(...args); }
+const _wrapped_linkContactToClient = withLogging('sac.tickets.linkContactToClient', _linkContactToClient);
+export async function linkContactToClient(...args: Parameters<typeof _linkContactToClient>) { return _wrapped_linkContactToClient(...args); }
+const _wrapped_createClientAndLink = withLogging('sac.tickets.createClientAndLink', _createClientAndLink);
+export async function createClientAndLink(...args: Parameters<typeof _createClientAndLink>) { return _wrapped_createClientAndLink(...args); }
+const _wrapped_getTicketRefunds = withLogging('sac.tickets.getTicketRefunds', _getTicketRefunds);
+export async function getTicketRefunds(...args: Parameters<typeof _getTicketRefunds>) { return _wrapped_getTicketRefunds(...args); }
+const _wrapped_getUserRole = withLogging('sac.tickets.getUserRole', _getUserRole);
+export async function getUserRole(...args: Parameters<typeof _getUserRole>) { return _wrapped_getUserRole(...args); }
+const _wrapped_requestRefund = withLogging('sac.tickets.requestRefund', _requestRefund);
+export async function requestRefund(...args: Parameters<typeof _requestRefund>) { return _wrapped_requestRefund(...args); }
+const _wrapped_approveRefund = withLogging('sac.tickets.approveRefund', _approveRefund);
+export async function approveRefund(...args: Parameters<typeof _approveRefund>) { return _wrapped_approveRefund(...args); }
+const _wrapped_rejectRefund = withLogging('sac.tickets.rejectRefund', _rejectRefund);
+export async function rejectRefund(...args: Parameters<typeof _rejectRefund>) { return _wrapped_rejectRefund(...args); }
+const _wrapped_executeRefund = withLogging('sac.tickets.executeRefund', _executeRefund);
+export async function executeRefund(...args: Parameters<typeof _executeRefund>) { return _wrapped_executeRefund(...args); }
+const _wrapped_getTicketListBootstrap = withLogging('sac.tickets.getTicketListBootstrap', _getTicketListBootstrap);
+export async function getTicketListBootstrap(...args: Parameters<typeof _getTicketListBootstrap>) { return _wrapped_getTicketListBootstrap(...args); }
+const _wrapped_addTag = withLogging('sac.tickets.addTag', _addTag);
+export async function addTag(...args: Parameters<typeof _addTag>) { return _wrapped_addTag(...args); }
+const _wrapped_removeTag = withLogging('sac.tickets.removeTag', _removeTag);
+export async function removeTag(...args: Parameters<typeof _removeTag>) { return _wrapped_removeTag(...args); }
+const _wrapped_getCancellationInfo = withLogging('sac.tickets.getCancellationInfo', _getCancellationInfo);
+export async function getCancellationInfo(...args: Parameters<typeof _getCancellationInfo>) { return _wrapped_getCancellationInfo(...args); }
+const _wrapped_requestCancellation = withLogging('sac.tickets.requestCancellation', _requestCancellation);
+export async function requestCancellation(...args: Parameters<typeof _requestCancellation>) { return _wrapped_requestCancellation(...args); }
+const _wrapped_approveCancellation = withLogging('sac.tickets.approveCancellation', _approveCancellation);
+export async function approveCancellation(...args: Parameters<typeof _approveCancellation>) { return _wrapped_approveCancellation(...args); }
+const _wrapped_getTicketDetailBootstrap = withLogging('sac.tickets.getTicketDetailBootstrap', _getTicketDetailBootstrap);
+export async function getTicketDetailBootstrap(...args: Parameters<typeof _getTicketDetailBootstrap>) { return _wrapped_getTicketDetailBootstrap(...args); }
+const _wrapped_getKanbanBootstrap = withLogging('sac.tickets.getKanbanBootstrap', _getKanbanBootstrap);
+export async function getKanbanBootstrap(...args: Parameters<typeof _getKanbanBootstrap>) { return _wrapped_getKanbanBootstrap(...args); }


### PR DESCRIPTION
## 🐛 Bug Crítico — Correção

### Problema
O erro `"use server" file can only export async functions, found object` quebrava TODAS as páginas do ERP em produção.

**Causa raiz:** O PR #402 introduziu o padrão `withLogging`, que faz:
```typescript
export const myAction = withLogging('name', _myAction);
```
O Next.js 14 valida em runtime que todos os exports de arquivos com `"use server"` sejam `async function` declarations. Um `export const` que retorna uma função — mesmo sendo async — **falha essa validação**.

### Fix (Opção B)
Manter o `"use server"` no topo, criar um const interno para o wrapper, e re-exportar como `async function` named com tipagem via `Parameters<typeof _fn>`:

```typescript
// ANTES (quebrado)
export const myAction = withLogging('name', _myAction);

// DEPOIS (correto)
const _wrapped_myAction = withLogging('name', _myAction);
export async function myAction(...args: Parameters<typeof _myAction>) {
  return _wrapped_myAction(...args);
}
```

### Escala
- **30 arquivos** modificados
- **~175 exports** corrigidos (todos os `actions.ts` do projeto)
- **Zero mudança de comportamento** — withLogging ainda envolve cada chamada

### Build
- O build falha com 2 erros **pré-existentes** em test files (`ra-reputation-card.test.tsx` e `sla-check-audit.test.ts`), confirmado que existem no `main` antes desta PR.
- A compilação TypeScript (`✓ Compiled successfully`) passa sem erros nas nossas mudanças.

### Arquivos afetados
Todos os `actions.ts` em: comercial, configuracoes, financeiro, fiscal, sac, dashboard.