### PR TITLE
refactor(sac): replace RA magic numbers with RA_STATUS constants + add tests

### DIFF
--- a/erp/src/app/(app)/sac/tickets/__tests__/dashboard-ra-kpis.test.ts
+++ b/erp/src/app/(app)/sac/tickets/__tests__/dashboard-ra-kpis.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { RA_STATUS } from "@/lib/reclameaqui/types";
+
+/**
+ * Unit tests for RA dashboard KPI query semantics.
+ * Validates that the constants used in dashboard-actions.ts match
+ * the expected Reclame Aqui status IDs from the HugMe API.
+ */
+describe("RA Dashboard KPI Constants", () => {
+  it("RESPONDIDO status ID should be 6 (Respondido / Aguardando consumidor)", () => {
+    expect(RA_STATUS.RESPONDIDO).toBe(6);
+  });
+
+  it("MODERACAO status ID should be 11 (Moderação pendente)", () => {
+    expect(RA_STATUS.MODERACAO).toBe(11);
+  });
+
+  it("NAO_RESPONDIDO status ID should be 5", () => {
+    expect(RA_STATUS.NAO_RESPONDIDO).toBe(5);
+  });
+
+  it("all RA_STATUS values should be unique numbers", () => {
+    const values = Object.values(RA_STATUS);
+    const uniqueValues = new Set(values);
+    expect(uniqueValues.size).toBe(values.length);
+    for (const v of values) {
+      expect(typeof v).toBe("number");
+    }
+  });
+
+  it("RA_STATUS should contain all documented status IDs", () => {
+    // All 13 documented RA status IDs per HugMe API
+    const expectedIds = [5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 18, 19, 20];
+    const actualIds = Object.values(RA_STATUS);
+    for (const id of expectedIds) {
+      expect(actualIds).toContain(id);
+    }
+  });
+});

--- a/erp/src/app/(app)/sac/tickets/dashboard-actions.ts
+++ b/erp/src/app/(app)/sac/tickets/dashboard-actions.ts
@@ -3,6 +3,7 @@
 import { requireCompanyAccess } from "@/lib/rbac";
 import { getCompanyKpis } from "@/lib/kpi-cache";
 import { prisma } from "@/lib/prisma";
+import { RA_STATUS } from "@/lib/reclameaqui/types";
 import type { ChannelType } from "@prisma/client";
 
 // ---------------------------------------------------------------------------
@@ -340,14 +341,14 @@ export async function getChannelDashboard(
         prisma.ticket.count({
           where: {
             ...channelWhere,
-            raStatusName: { contains: "Respondid" },
+            raStatusId: RA_STATUS.RESPONDIDO,
           },
         }),
         prisma.ticket.count({
           where: { ...channelWhere, raResolvedIssue: true },
         }),
         prisma.ticket.count({
-          where: { ...channelWhere, raStatusId: 11 },
+          where: { ...channelWhere, raStatusId: RA_STATUS.MODERACAO },
         }),
         prisma.ticket.count({
           where: { ...channelWhere, raSlaDeadline: { not: null }, slaAtRisk: true, slaBreached: false, status: { in: ["OPEN", "IN_PROGRESS", "WAITING_CLIENT"] } },


### PR DESCRIPTION
## Follow-up do PR #421 (recomendações QA + TechLead)

### Mudanças

1. **Import `RA_STATUS` de `lib/reclameaqui/types.ts`** no dashboard-actions.ts
2. **`raStatusName: { contains: "Respondid" }` → `raStatusId: RA_STATUS.RESPONDIDO`** (6)
   - String match parcial era frágil — quebraria silenciosamente se o RA renomeasse o status
3. **`raStatusId: 11` → `RA_STATUS.MODERACAO`** — constante nomeada em vez de magic number
4. **5 testes unitários** validando constantes RA_STATUS (valores, unicidade, completude vs 13 status documentados)

### Revisado e descartado
- `ra-actions.ts:133` usa `raCanModerate` como campo de SELECT (não filtro) e na linha 170 como elegibilidade de botão — semântica correta, sem alteração necessária

### Testes
```
✓ dashboard-ra-kpis.test.ts (5 tests) 7ms
  ✓ RESPONDIDO status ID should be 6
  ✓ MODERACAO status ID should be 11
  ✓ NAO_RESPONDIDO status ID should be 5
  ✓ all RA_STATUS values should be unique numbers
  ✓ RA_STATUS should contain all documented status IDs
```