### PR TITLE
fix: cast ChannelType to text in COALESCE — SAC tickets voltam a listar

### DIFF
--- a/erp/src/lib/kpi-cache.ts
+++ b/erp/src/lib/kpi-cache.ts
@@ -157,12 +157,12 @@ export async function getCompanyKpis(
     }),
     // Group by channel type via raw SQL (join with channels table)
     prisma.$queryRaw<{ channel: string; count: bigint }[]>`
-      SELECT COALESCE(c."type", 'WEB') as channel, COUNT(*)::bigint as count
+      SELECT COALESCE(c."type"::text, 'WEB') as channel, COUNT(*)::bigint as count
       FROM tickets t
       LEFT JOIN channels c ON t."channelId" = c.id
       WHERE t."companyId" = ${companyId}
         AND t.status IN ('OPEN', 'IN_PROGRESS', 'WAITING_CLIENT')
-      GROUP BY COALESCE(c."type", 'WEB')
+      GROUP BY COALESCE(c."type"::text, 'WEB')
     `,
     // Average response time (minutes from ticket creation to first message)
     prisma.$queryRaw<{ avg_minutes: number | null }[]>`


### PR DESCRIPTION
## Problema

A query `getCompanyKpis()` em `kpi-cache.ts` usava:

```sql
SELECT COALESCE(c."type", 'WEB') as channel, ...
GROUP BY COALESCE(c."type", 'WEB')
```

Como `c."type"` é do tipo enum `ChannelType` no PostgreSQL, o banco tentava coercer a string literal `'WEB'` para o enum — e falhava com `22P02` porque `WEB` não existe no enum `{EMAIL, WHATSAPP, RECLAMEAQUI}`.

## Fix

Adicionar cast `::text` antes do COALESCE:

```sql
SELECT COALESCE(c."type"::text, 'WEB') as channel, ...
GROUP BY COALESCE(c."type"::text, 'WEB')
```

## Impacto

- Corrige `getTicketListBootstrap` que explodia com code `22P02`
- SAC ticket list volta a exibir os 61+ tickets da TrustCloud/Reclame Aqui
- Nenhuma migration necessária — fix apenas no código da query

## Arquivos

- `erp/src/lib/kpi-cache.ts` (2 linhas alteradas)