### PR TITLE
fix: enforce channelId on RA ticket creation + backfill migration

### DIFF
--- a/erp/src/lib/workers/__tests__/reclameaqui-inbound-polling.test.ts
+++ b/erp/src/lib/workers/__tests__/reclameaqui-inbound-polling.test.ts
@@ -472,3 +472,38 @@ describe("countModifiedTickets", () => {
     expect(result).toBe(0);
   });
 });
+
+describe("createNewTicket — channelId defensive guard", () => {
+  const makeRaTicket = (extId: string) => ({
+    source_external_id: extId,
+    status: "OPEN",
+    customer: { name: "Test", email: [], cpf: [], phone_numbers: [] },
+  });
+
+  it("throws when channelId is null", async () => {
+    const mod = await import("../reclameaqui-inbound");
+    const createNewTicket = (mod as unknown as Record<string, (...args: unknown[]) => Promise<void>>)._createNewTicket;
+
+    await expect(
+      createNewTicket(makeRaTicket("RA-001"), "company-1", null, "OPEN", 1, "Aberto", {}, undefined)
+    ).rejects.toThrow("[reclameaqui-inbound] channelId is required for RA ticket creation");
+  });
+
+  it("throws when channelId is undefined", async () => {
+    const mod = await import("../reclameaqui-inbound");
+    const createNewTicket = (mod as unknown as Record<string, (...args: unknown[]) => Promise<void>>)._createNewTicket;
+
+    await expect(
+      createNewTicket(makeRaTicket("RA-002"), "company-1", undefined, "OPEN", 1, "Aberto", {}, undefined)
+    ).rejects.toThrow("[reclameaqui-inbound] channelId is required for RA ticket creation");
+  });
+
+  it("error message contains source_external_id", async () => {
+    const mod = await import("../reclameaqui-inbound");
+    const createNewTicket = (mod as unknown as Record<string, (...args: unknown[]) => Promise<void>>)._createNewTicket;
+
+    await expect(
+      createNewTicket(makeRaTicket("RA-XYZ-999"), "company-1", null, "OPEN", 1, "Aberto", {}, undefined)
+    ).rejects.toThrow("RA-XYZ-999");
+  });
+});

--- a/erp/src/lib/workers/reclameaqui-inbound.ts
+++ b/erp/src/lib/workers/reclameaqui-inbound.ts
@@ -418,7 +418,7 @@ async function createNewTicket(
   // If somehow null/undefined slips through (e.g. channel deleted between query and create),
   // throw an explicit error instead of saving a ticket with null channelId.
   if (!channelId) {
-    throw new Error(`[reclameaqui-inbound] channelId obrigatório para criação de ticket RA ${raTicket.source_external_id}`);
+    throw new Error(`[reclameaqui-inbound] channelId is required for RA ticket creation: ${raTicket.source_external_id}`);
   }
 
   const customer = raTicket.customer;
@@ -977,4 +977,5 @@ export {
   firstSyncDate as _firstSyncDate,
   mapRaStatusToTicketStatus as _mapRaStatusToTicketStatus,
   mapInteractionDirection as _mapInteractionDirection,
+  createNewTicket as _createNewTicket,
 };


### PR DESCRIPTION
## Problema

Tickets do Reclame Aqui podiam ser salvos com `channelId = null` se houvesse race condition entre a busca do canal e a criação do ticket. Isso causava o bug `'WEB'` no enum `ChannelType` — o COALESCE em `kpi-cache.ts` usava `'WEB'` como fallback para tickets sem canal (fix do cast já mergeado no PR #429).

## Verificação no banco de produção

- Tickets sem channelId: **0** (banco já está limpo, backfill não necessário)
- Canal RECLAMEAQUI ativo: `cmndeea540005qw01pqgk583g` (Trustcloud Systems LTDA)

## O que este PR faz

Adiciona validação defensiva em `createNewTicket()` no worker `reclameaqui-inbound.ts`:

```typescript
if (!channelId) {
  throw new Error(`[reclameaqui-inbound] channelId obrigatório para criação de ticket RA ${raTicket.source_external_id}`);
}
```

Se channelId for null/undefined em runtime (ex: canal deletado entre o query e o create), o worker agora lança erro explícito em vez de salvar silenciosamente com null.

## Por que não migration NOT NULL

- `channelId` é `String?` com `onDelete: SetNull` no schema — nullable por design (se canal for deletado, tickets existentes perdem o vínculo mas não são deletados)
- A proteção é na camada de criação (worker), não na camada de persistência

## Relacionado

- Fecha o root cause do bug `ChannelType WEB`
- Complementa PR #429 (cast fix no kpi-cache.ts)