### PR TITLE
fix(ai-config): enable RECLAMEAQUI channel in simulator

### DIFF
--- a/erp/src/app/(app)/configuracoes/ai/actions.ts
+++ b/erp/src/app/(app)/configuracoes/ai/actions.ts
@@ -559,7 +559,7 @@ async function _getSuggestedModel(
 async function _simulateAiResponse(
   companyId: string,
   message: string,
-  channel: "WHATSAPP" | "EMAIL",
+  channel: "WHATSAPP" | "EMAIL" | "RECLAMEAQUI",
 ): Promise<SimulationResult> {
   await requireAdmin();
   await requireCompanyAccess(companyId);
@@ -586,7 +586,7 @@ async function _simulateAiResponse(
   }
 
   // Runtime validation for channel (TypeScript-only types aren't enforced at HTTP boundaries)
-  const VALID_CHANNELS = ["WHATSAPP", "EMAIL"] as const;
+  const VALID_CHANNELS = ["WHATSAPP", "EMAIL", "RECLAMEAQUI"] as const;
   if (!VALID_CHANNELS.includes(channel as (typeof VALID_CHANNELS)[number])) {
     return {
       response: "",
@@ -623,6 +623,7 @@ async function _simulateAiResponse(
       "api_key_decrypt_failed": "Erro ao acessar a configuração de API key.",
       "email_channel_disabled": "Canal Email está desabilitado nas configurações.",
       "whatsapp_channel_disabled": "Canal WhatsApp está desabilitado nas configurações.",
+      "reclameaqui_channel_disabled": "Canal Reclame Aqui está desabilitado nas configurações.",
       "AI not enabled": "A IA está desabilitada. Habilite nas configurações gerais.",
       "daily_spend_limit_reached": "Limite de gasto diário atingido.",
       "max iterations reached": "Limite de iterações atingido sem resposta.",

--- a/erp/src/app/(app)/configuracoes/ai/components/tab-canais.tsx
+++ b/erp/src/app/(app)/configuracoes/ai/components/tab-canais.tsx
@@ -238,7 +238,7 @@ function ChannelSimulatorCard({
   channel,
 }: {
   companyId: string;
-  channel: "WHATSAPP" | "EMAIL";
+  channel: "WHATSAPP" | "EMAIL" | "RECLAMEAQUI";
 }) {
   const [simMessage, setSimMessage] = useState("");
   const [simRunning, setSimRunning] = useState(false);
@@ -459,7 +459,7 @@ function SectionWhatsApp({ companyId, config, setConfig }: TabCanaisProps) {
       />
 
       {/* Card 6: Simulador */}
-      <ChannelSimulatorCard companyId={companyId} channel="WHATSAPP" />
+      <ChannelSimulatorCard companyId={companyId} channel="RECLAMEAQUI" />
     </div>
   );
 }
@@ -773,8 +773,8 @@ function SectionReclameAqui({ companyId, config, setConfig }: TabCanaisProps) {
         setToolState={setRaTools}
       />
 
-      {/* Card 6: Simulador — RA não tem canal separado, usar WHATSAPP como fallback */}
-      <ChannelSimulatorCard companyId={companyId} channel="WHATSAPP" />
+      {/* Card 6: Simulador RA */}
+      <ChannelSimulatorCard companyId={companyId} channel="RECLAMEAQUI" />
     </div>
   );
 }


### PR DESCRIPTION
Simulador na aba Reclame Aqui não funcionava porque simulateAiResponse só aceitava WHATSAPP|EMAIL.

**Root cause:** VALID_CHANNELS não incluía RECLAMEAQUI, retornando 'Canal inválido' silenciosamente.

**Fix:**
- actions.ts: adicionado RECLAMEAQUI aos VALID_CHANNELS e ao errorMap
- tab-canais.tsx: ChannelSimulatorCard do RA agora passa channel="RECLAMEAQUI" (era WHATSAPP como fallback)