### PR TITLE
fix(whatsapp-service): add HEALTHCHECK to reflect real container state

### DIFF
--- a/whatsapp-service/Dockerfile
+++ b/whatsapp-service/Dockerfile
@@ -26,4 +26,7 @@ RUN mkdir -p /app/uploads
 
 EXPOSE 3001
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:3001/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
+
 CMD ["node", "dist/index.js"]

--- a/whatsapp-service/Dockerfile
+++ b/whatsapp-service/Dockerfile
@@ -27,6 +27,6 @@ RUN mkdir -p /app/uploads
 EXPOSE 3001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD node -e "require('http').get('http://127.0.0.1:3001/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
+  CMD node -e "const p=process.env.WHATSAPP_SERVICE_PORT||3001;require('http').get('http://127.0.0.1:'+p+'/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- Adds a native Docker `HEALTHCHECK` to `whatsapp-service/Dockerfile` that probes the existing `/health` endpoint on port 3001.
- Uses `node` directly (no `curl`/`wget` install needed) — zero image-size impact.
- Fixes the stale `running:unhealthy` status shown in Coolify for the WhatsApp service container.

## Context
The container has been up for 6+ days showing `running:unhealthy` even though Coolify's healthcheck toggle was disabled. Root cause: the Docker health state was never reset, and the image had no `HEALTHCHECK` instruction to report real state. By baking a proper healthcheck into the image, Coolify (and `docker ps`) will reflect the actual service state.

## Post-merge steps in Coolify
1. Enable the *Health check* toggle on the `whatsapp-service` resource.
2. Redeploy with **Force rebuild** so Docker picks up the new `HEALTHCHECK` layer.
3. Status should transition to `running:healthy` within ~1 minute.

## Test plan
- [ ] Build the image locally: `docker build -t wa-svc whatsapp-service/`
- [ ] Run: `docker run -d --name wa wa-svc` (with required env)
- [ ] Verify after ~30s: `docker inspect wa --format '{{.State.Health.Status}}'` returns `healthy`
- [ ] Deploy to Coolify and confirm status flips from `unhealthy` to `healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)